### PR TITLE
Add IRewardModifyingZone

### DIFF
--- a/src/main/java/spireMapOverhaul/patches/interfacePatches/RewardModifierPatches.java
+++ b/src/main/java/spireMapOverhaul/patches/interfacePatches/RewardModifierPatches.java
@@ -1,5 +1,6 @@
 package spireMapOverhaul.patches.interfacePatches;
 
+import basemod.ReflectionHacks;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
@@ -7,6 +8,8 @@ import com.megacrit.cardcrawl.rewards.RewardItem;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.saveAndContinue.SaveAndContinue;
 import com.megacrit.cardcrawl.screens.CombatRewardScreen;
+import com.megacrit.cardcrawl.vfx.FastCardObtainEffect;
+import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect;
 import javassist.CtBehavior;
 import spireMapOverhaul.abstracts.AbstractZone;
 import spireMapOverhaul.util.Wiz;
@@ -79,6 +82,34 @@ public class RewardModifierPatches {
                 Matcher firstMatcher = new Matcher.MethodCallMatcher(SaveAndContinue.class, "save");
                 Matcher finalMatcher = new Matcher.FieldAccessMatcher(AbstractDungeon.class, "loading_post_combat");
                 return LineFinder.findInOrder(ctMethodToPatch, Collections.singletonList(firstMatcher), finalMatcher);
+            }
+        }
+    }
+
+    @SpirePatch2(clz = ShowCardAndObtainEffect.class, method = "update")
+    public static class OnObtainCardShowCardAndObtainPatch {
+        @SpirePostfixPatch
+        public static void OnObtainCardPatch(ShowCardAndObtainEffect __instance) {
+            AbstractZone zone = Wiz.getCurZone();
+            if (zone instanceof IRewardModifyingZone) {
+                AbstractCard card = ReflectionHacks.getPrivate(__instance, ShowCardAndObtainEffect.class, "card");
+                if (__instance.isDone) {
+                    ((IRewardModifyingZone)zone).onObtainCard(card);
+                }
+            }
+        }
+    }
+
+    @SpirePatch2(clz = FastCardObtainEffect.class, method = "update")
+    public static class OnObtainCardFastCardObtainPatch {
+        @SpirePostfixPatch
+        public static void OnObtainCardPatch(FastCardObtainEffect __instance) {
+            AbstractZone zone = Wiz.getCurZone();
+            if (zone instanceof IRewardModifyingZone) {
+                AbstractCard card = ReflectionHacks.getPrivate(__instance, FastCardObtainEffect.class, "card");
+                if (__instance.isDone) {
+                    ((IRewardModifyingZone)zone).onObtainCard(card);
+                }
             }
         }
     }

--- a/src/main/java/spireMapOverhaul/patches/interfacePatches/RewardModifierPatches.java
+++ b/src/main/java/spireMapOverhaul/patches/interfacePatches/RewardModifierPatches.java
@@ -113,4 +113,15 @@ public class RewardModifierPatches {
             }
         }
     }
+
+    @SpirePatch2(clz = AbstractRoom.class, method = "alterCardRarityProbabilities")
+    public static class ChangeRareCardRewardChancePatch {
+        @SpirePostfixPatch
+        public static void ChangeRareCardRewardChance(AbstractRoom __instance) {
+            AbstractZone zone = Wiz.getCurZone();
+            if (zone instanceof IRewardModifyingZone) {
+                __instance.rareCardChance = ((IRewardModifyingZone)zone).changeRareCardRewardChance((__instance.rareCardChance));
+            }
+        }
+    }
 }

--- a/src/main/java/spireMapOverhaul/patches/interfacePatches/RewardModifierPatches.java
+++ b/src/main/java/spireMapOverhaul/patches/interfacePatches/RewardModifierPatches.java
@@ -1,0 +1,85 @@
+package spireMapOverhaul.patches.interfacePatches;
+
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.rewards.RewardItem;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
+import com.megacrit.cardcrawl.saveAndContinue.SaveAndContinue;
+import com.megacrit.cardcrawl.screens.CombatRewardScreen;
+import javassist.CtBehavior;
+import spireMapOverhaul.abstracts.AbstractZone;
+import spireMapOverhaul.util.Wiz;
+import spireMapOverhaul.zoneInterfaces.IRewardModifyingZone;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class RewardModifierPatches {
+    @SpirePatch2(clz = CombatRewardScreen.class, method = "setupItemReward")
+    public static class AddCardRewardsPatch {
+        @SpireInsertPatch(locator = Locator.class)
+        public static void AddCardRewards(CombatRewardScreen __instance) {
+            AbstractZone zone = Wiz.getCurZone();
+            if (zone instanceof IRewardModifyingZone) {
+                ArrayList<ArrayList<AbstractCard>> additionalCardRewards = ((IRewardModifyingZone)zone).getAdditionalCardRewards();
+                for (ArrayList<AbstractCard> cards : additionalCardRewards) {
+                    RewardItem rewardItem = new RewardItem();
+                    rewardItem.cards = cards;
+                    __instance.rewards.add(rewardItem);
+                }
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+                Matcher matcher = new Matcher.NewExprMatcher(RewardItem.class);
+                int[] lines = LineFinder.findAllInOrder(ctMethodToPatch, matcher);
+                // We only want the first two uses, which are respectively the branch for the Vintage modifier (only
+                // elites and bosses drop cards) and the normal branch. The third use is for Prayer Wheel.
+                // The reason this matters (and why this isn't just a postfix patch) is because want to avoid adding
+                // additional card rewards to fights that normally don't drop rewards, and we don't want to reproduce
+                // the logic that CombatRewardScreen.setupItemRewards has for that.
+                return new int[] { lines[0], lines[1] };
+            }
+        }
+    }
+
+    @SpirePatch2(clz = AbstractRoom.class, method = "update")
+    public static class ModifyRewardsPatch {
+        @SpireInsertPatch(locator = Locator.class)
+        public static void ModifyRewards(AbstractRoom __instance) {
+            AbstractZone zone = Wiz.getCurZone();
+            if (zone instanceof IRewardModifyingZone) {
+                // We don't want to affect uses of CombatRewardScreen that are in non-battle events such as Sensory Stone
+                if (AbstractDungeon.getCurrMapNode() != null && AbstractDungeon.getCurrMapNode().room != null && AbstractDungeon.getCurrMapNode().room.isBattleOver) {
+                    IRewardModifyingZone z = ((IRewardModifyingZone)zone);
+                    for (RewardItem rewardItem : AbstractDungeon.combatRewardScreen.rewards) {
+                        if (rewardItem.type == RewardItem.RewardType.CARD && rewardItem.cards != null && !rewardItem.cards.isEmpty()) {
+                            z.modifyRewardCards(rewardItem.cards);
+                        }
+                        z.modifyReward(rewardItem);
+                    }
+                    AbstractDungeon.combatRewardScreen.rewards.addAll(z.getAdditionalRewards());
+                    z.modifyRewards(AbstractDungeon.combatRewardScreen.rewards);
+                }
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+                // We ensure that this happens after the save file is made, outside of any checks for loading saves
+                // The block of rewards code this is part of runs both when you win a combat and when you save/reload
+                // after combat, and the game relies on doing things in a specific order and monkeying with rng in ways
+                // that make it very easy to create save/reload inconsistencies when adding or changing rewards
+                // By ensuring that our patch happens after the save file is made, outside of any checks for loading saves,
+                // we sidestep these issues
+                Matcher firstMatcher = new Matcher.MethodCallMatcher(SaveAndContinue.class, "save");
+                Matcher finalMatcher = new Matcher.FieldAccessMatcher(AbstractDungeon.class, "loading_post_combat");
+                return LineFinder.findInOrder(ctMethodToPatch, Collections.singletonList(firstMatcher), finalMatcher);
+            }
+        }
+    }
+}

--- a/src/main/java/spireMapOverhaul/zoneInterfaces/IRewardModifyingZone.java
+++ b/src/main/java/spireMapOverhaul/zoneInterfaces/IRewardModifyingZone.java
@@ -72,4 +72,13 @@ public interface IRewardModifyingZone {
      * @param card The card added.
      */
     default void onObtainCard(AbstractCard card) {}
+
+    /**
+     * Hook for changing the chance of rare cards in rewards.
+     * @param rareCardRewardChance The base chance of rare cards in rewards. Effects such as N'loth's Gift are already applied.
+     * @return The new rare card reward chance.
+     */
+    default int changeRareCardRewardChance(int rareCardRewardChance) {
+        return rareCardRewardChance;
+    }
 }

--- a/src/main/java/spireMapOverhaul/zoneInterfaces/IRewardModifyingZone.java
+++ b/src/main/java/spireMapOverhaul/zoneInterfaces/IRewardModifyingZone.java
@@ -66,4 +66,10 @@ public interface IRewardModifyingZone {
      * @param rewards The set of rewards.
      */
     default void modifyRewards(ArrayList<RewardItem> rewards) {}
+
+    /**
+     * Hook for triggering effects when a card is added to the deck.
+     * @param card The card added.
+     */
+    default void onObtainCard(AbstractCard card) {}
 }

--- a/src/main/java/spireMapOverhaul/zoneInterfaces/IRewardModifyingZone.java
+++ b/src/main/java/spireMapOverhaul/zoneInterfaces/IRewardModifyingZone.java
@@ -1,0 +1,69 @@
+package spireMapOverhaul.zoneInterfaces;
+
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.rewards.RewardItem;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+public interface IRewardModifyingZone {
+    /**
+     * Hook for adding any number of additional card rewards.
+     * AbstractDungeon.cardRng should be the only RNG used in this method.
+     * @return A list where each entry is the set of cards that should go in a card reward.
+     */
+    default ArrayList<ArrayList<AbstractCard>> getAdditionalCardRewards() {
+        ArrayList<AbstractCard> cards = getAdditionalCardReward();
+        return cards == null ? new ArrayList<>() : new ArrayList<>(Collections.singletonList(cards));
+    }
+
+    /**
+     * Hook for adding a single additional card rewards (a convenience wrapper for getAdditionalCardRewards).
+     * AbstractDungeon.cardRng should be the only RNG used in this method.
+     * @return The list of cards that should go in a card reward.
+     */
+    default ArrayList<AbstractCard> getAdditionalCardReward() {
+        return null;
+    }
+
+    /**
+     * Hook for adding any number of additional rewards.
+     * @return A list of rewards to add.
+     */
+    default ArrayList<RewardItem> getAdditionalRewards() {
+        RewardItem reward = getAdditionalReward();
+        return reward == null ? new ArrayList<>() : new ArrayList<>(Collections.singletonList(reward));
+    }
+    /**
+     * Hook for adding a single additional rewards (a convenience wrapper for getAdditionalRewards).
+     * @return A list of rewards to add.
+     */
+    default RewardItem getAdditionalReward() { return null; }
+
+    /**
+     * Hook for modifying the cards in each card reward.
+     * You can add or remove cards, add card modifiers, etc.
+     * Note that if you both add additional card rewards through getAdditionalCardRewards and implement this,
+     * this will get called on the rewards you added.
+     * @param cards The cards in the reward.
+     */
+    default void modifyRewardCards(ArrayList<AbstractCard> cards) {}
+
+    /**
+     * Hook for modifying each reward.
+     * Check the rewardItem's type to determine what kind of reward it is (card, gold, relic, etc.).
+     * You can change values (e.g. increase or reduce gold), substitute relics, change the image, etc.
+     * Note that if you both add additional rewards and implement this, this will get called on the rewards you added.
+     * For card rewards, this will be called after modifications from modifyRewardCards.
+     * @param rewardItem The reward.
+     */
+    default void modifyReward(RewardItem rewardItem) {}
+
+    /**
+     * Hook for modifying the set of rewards.
+     * You can remove rewards. For other use cases, it's be better to use one of the modify or getAdditional methods.
+     * Note that the list of rewards will include any additional rewards you added and any modifications you made.
+     * @param rewards The set of rewards.
+     */
+    default void modifyRewards(ArrayList<RewardItem> rewards) {}
+}

--- a/src/main/java/spireMapOverhaul/zones/example/ExampleRewardModifyingZone.java
+++ b/src/main/java/spireMapOverhaul/zones/example/ExampleRewardModifyingZone.java
@@ -77,4 +77,9 @@ public class ExampleRewardModifyingZone extends AbstractZone implements IRewardM
     public void onObtainCard(AbstractCard c) {
         AbstractDungeon.player.increaseMaxHp(1, false);
     }
+
+    @Override
+    public int changeRareCardRewardChance(int rareCardRewardChance) {
+        return rareCardRewardChance + 50;
+    }
 }

--- a/src/main/java/spireMapOverhaul/zones/example/ExampleRewardModifyingZone.java
+++ b/src/main/java/spireMapOverhaul/zones/example/ExampleRewardModifyingZone.java
@@ -1,0 +1,75 @@
+package spireMapOverhaul.zones.example;
+
+import basemod.cardmods.EtherealMod;
+import basemod.helpers.CardModifierManager;
+import com.badlogic.gdx.graphics.Color;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.relics.Circlet;
+import com.megacrit.cardcrawl.rewards.RewardItem;
+import spireMapOverhaul.SpireAnniversary6Mod;
+import spireMapOverhaul.abstracts.AbstractZone;
+import spireMapOverhaul.zoneInterfaces.IRewardModifyingZone;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class ExampleRewardModifyingZone extends AbstractZone implements IRewardModifyingZone {
+    public static final String ID = "ExampleRewardModifying";
+
+    public ExampleRewardModifyingZone() {
+        super(ID);
+        this.width = 3;
+        this.height = 3;
+    }
+
+    @Override
+    public AbstractZone copy() {
+        return new ExampleRewardModifyingZone();
+    }
+
+    @Override
+    public Color getColor() {
+        return Color.RED.cpy();
+    }
+
+    @Override
+    public ArrayList<AbstractCard> getAdditionalCardReward() {
+        AbstractCard c1 = AbstractDungeon.getCard(AbstractCard.CardRarity.UNCOMMON);
+        AbstractCard c2 = AbstractDungeon.getCard(AbstractCard.CardRarity.UNCOMMON);
+        AbstractCard c3 = AbstractDungeon.getCard(AbstractCard.CardRarity.UNCOMMON);
+        return new ArrayList<>(Arrays.asList(c1, c2, c3));
+    }
+
+    @Override
+    public RewardItem getAdditionalReward() {
+        if (AbstractDungeon.treasureRng.randomBoolean()) {
+            return new RewardItem(new Circlet());
+        }
+        return null;
+    }
+
+    @Override
+    public void modifyRewardCards(ArrayList<AbstractCard> cards) {
+        for (AbstractCard card : cards) {
+            CardModifierManager.addModifier(card, new EtherealMod());
+        }
+    }
+
+    @Override
+    public void modifyReward(RewardItem rewardItem) {
+        if (rewardItem.type == RewardItem.RewardType.GOLD) {
+            float multiplier = AbstractDungeon.treasureRng.random(1.5f, 2.0f);
+            SpireAnniversary6Mod.logger.info("Multiplying gold amount by " + multiplier);
+            rewardItem.goldAmt = (int)(rewardItem.goldAmt * multiplier);
+        }
+    }
+
+    @Override
+    public void modifyRewards(ArrayList<RewardItem> rewards) {
+        if (AbstractDungeon.treasureRng.randomBoolean()) {
+            SpireAnniversary6Mod.logger.info("Removing all non-Circlet relics");
+            rewards.removeIf(r -> r.type == RewardItem.RewardType.RELIC && !(r.relic instanceof Circlet));
+        }
+    }
+}

--- a/src/main/java/spireMapOverhaul/zones/example/ExampleRewardModifyingZone.java
+++ b/src/main/java/spireMapOverhaul/zones/example/ExampleRewardModifyingZone.java
@@ -4,6 +4,7 @@ import basemod.cardmods.EtherealMod;
 import basemod.helpers.CardModifierManager;
 import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.colorless.MindBlast;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.relics.Circlet;
 import com.megacrit.cardcrawl.rewards.RewardItem;
@@ -51,6 +52,7 @@ public class ExampleRewardModifyingZone extends AbstractZone implements IRewardM
 
     @Override
     public void modifyRewardCards(ArrayList<AbstractCard> cards) {
+        cards.add(new MindBlast());
         for (AbstractCard card : cards) {
             CardModifierManager.addModifier(card, new EtherealMod());
         }

--- a/src/main/java/spireMapOverhaul/zones/example/ExampleRewardModifyingZone.java
+++ b/src/main/java/spireMapOverhaul/zones/example/ExampleRewardModifyingZone.java
@@ -72,4 +72,9 @@ public class ExampleRewardModifyingZone extends AbstractZone implements IRewardM
             rewards.removeIf(r -> r.type == RewardItem.RewardType.RELIC && !(r.relic instanceof Circlet));
         }
     }
+
+    @Override
+    public void onObtainCard(AbstractCard c) {
+        AbstractDungeon.player.increaseMaxHp(1, false);
+    }
 }

--- a/src/main/resources/anniv6Resources/localization/eng/ExampleRewardModifying/UIstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/ExampleRewardModifying/UIstrings.json
@@ -1,0 +1,7 @@
+{
+  "${ModID}:ExampleRewardModifying": {
+    "TEXT": [
+      "Example Reward Modifying"
+    ]
+  }
+}


### PR DESCRIPTION
This is the first cut of `IRewardModifyingZone`. I put this together pretty quickly so I haven't tested all the small interactions and edge cases yet, but the core should work.

I built this with a few thoughts in mind:
* Provide a simple way of doing common operations
* Start with a core set on methods with high flexibility so that a broad range of use cases are supported with a bit more work
* Make it hard to screw things up in a way that makes saving and reloading change the rewards

The documentation comments plus the example will hopefully be enough to understand what's going on. 

For the overall shape of the API, I took a look through the ideas spreadsheet and this should meet the needs of many of the reward modifiers listed so far. There are some potential extensions to this that I considered but didn't put in the initial version:
* Methods that hook into the normal relic and potion drop logic to let zones define their own distribution. There are ways to achieve this with the current hooks, by replacing the generated relic/potion with your own, but it might be nice to have more direct support. A moderate number of zones would benefit from this.
* A method for not being able to skip card rewards. This may be needed for Dayvig's Scrapyard zone ("You gain 2 cards rewards from combat, but cannot skip card rewards (anywhere)").
* Any support specific to `CustomReward`. They can be added in the methods for getting additional rewards, and I didn't see a clear need for anything beyond that. TBD how much people even want to make custom rewards, the only things that jumped out at me as maybe needing them are from Rucodeby's Laser Area ("Chance to take a modifier for cards that enchance their damage instead card reward") and Vex's Hatlands ("New reward type: Hat.").

None of these are obviously needed to me, so I thought it made sense to discuss before adding any of them. Once the foundation added by this PR is in place, it won't be hard to add new methods, and we can work out what we want to have before opening things up for contributions.