### PR TITLE
Show the zone for each node in the run history screen

### DIFF
--- a/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
+++ b/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
@@ -29,6 +29,7 @@ import com.megacrit.cardcrawl.unlock.UnlockTracker;
 import javassist.CtClass;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import spireMapOverhaul.patches.ZonePerFloorRunHistoryPatch;
 import spireMapOverhaul.patches.interfacePatches.CampfireModifierPatches;
 import spireMapOverhaul.patches.CustomRewardTypes;
 import spireMapOverhaul.abstracts.AbstractSMORelic;
@@ -208,6 +209,7 @@ public class SpireAnniversary6Mod implements
     @Override
     public void receivePostInitialize() {
         initializedStrings = true;
+        unfilteredAllZones.forEach(AbstractZone::loadStrings);
         allZones.sort(Comparator.comparing(c->c.id));
         addMonsters();
         addPotions();
@@ -237,6 +239,7 @@ public class SpireAnniversary6Mod implements
     }
 
     public static void addSaveFields() {
+        BaseMod.addSaveField(ZonePerFloorRunHistoryPatch.ZonePerFloorLog.SaveKey, new ZonePerFloorRunHistoryPatch.ZonePerFloorLog());
         BaseMod.addSaveField(EncounterModifierPatches.LastZoneNormalEncounter.SaveKey, new EncounterModifierPatches.LastZoneNormalEncounter());
         BaseMod.addSaveField(EncounterModifierPatches.LastZoneEliteEncounter.SaveKey, new EncounterModifierPatches.LastZoneEliteEncounter());
     }

--- a/src/main/java/spireMapOverhaul/abstracts/AbstractZone.java
+++ b/src/main/java/spireMapOverhaul/abstracts/AbstractZone.java
@@ -96,7 +96,7 @@ public abstract class AbstractZone {
         return ActUtil.getRealActNum() == actNum;
     }
 
-    protected void loadStrings() {
+    public void loadStrings() {
         if (SpireAnniversary6Mod.initializedStrings) {
             TEXT = CardCrawlGame.languagePack.getUIString(makeID(this.id)).TEXT;
             name = TEXT[0];

--- a/src/main/java/spireMapOverhaul/patches/ZonePerFloorRunHistoryPatch.java
+++ b/src/main/java/spireMapOverhaul/patches/ZonePerFloorRunHistoryPatch.java
@@ -1,0 +1,157 @@
+package spireMapOverhaul.patches;
+
+import basemod.BaseMod;
+import basemod.ReflectionHacks;
+import basemod.abstracts.CustomSavable;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.evacipated.cardcrawl.modthespire.patcher.PatchingException;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.metrics.Metrics;
+import com.megacrit.cardcrawl.monsters.MonsterGroup;
+import com.megacrit.cardcrawl.screens.runHistory.RunHistoryPath;
+import com.megacrit.cardcrawl.screens.runHistory.RunPathElement;
+import com.megacrit.cardcrawl.screens.stats.RunData;
+import javassist.*;
+import org.apache.logging.log4j.Logger;
+import spireMapOverhaul.SpireAnniversary6Mod;
+import spireMapOverhaul.abstracts.AbstractZone;
+import spireMapOverhaul.patches.interfacePatches.EncounterModifierPatches;
+import spireMapOverhaul.util.Wiz;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class ZonePerFloorRunHistoryPatch {
+    private static final Logger logger = SpireAnniversary6Mod.logger;
+    private static final String ZONE_TEXT = CardCrawlGame.languagePack.getUIString(SpireAnniversary6Mod.makeID("RunHistoryScreen")).TEXT[0];
+
+    @SpirePatch(clz = CardCrawlGame.class, method = SpirePatch.CONSTRUCTOR)
+    public static class ZonePerFloorField {
+        @SpireRawPatch
+        public static void addZonePerFloor(CtBehavior ctBehavior) throws NotFoundException, CannotCompileException {
+            CtClass runData = ctBehavior.getDeclaringClass().getClassPool().get(RunData.class.getName());
+
+            String fieldSource = "public java.util.List zone_per_floor;";
+
+            CtField field = CtField.make(fieldSource, runData);
+
+            runData.addField(field);
+        }
+    }
+
+    @SpirePatch(clz = Metrics.class, method = "gatherAllData")
+    public static class GatherAllDataPatch {
+        @SpirePostfixPatch
+        public static void gatherAllDataPatch(Metrics __instance, boolean death, boolean trueVictor, MonsterGroup monsters) {
+            if (death) {
+                AbstractZone zone = Wiz.getCurZone();
+                String zoneID = zone == null ? null : zone.id;
+                ZonePerFloorLog.zonePerFloorLog.add(zoneID);
+            }
+            ReflectionHacks.privateMethod(Metrics.class, "addData", Object.class, Object.class)
+                    .invoke(__instance, "zone_per_floor", ZonePerFloorLog.zonePerFloorLog);
+        }
+    }
+
+    @SpirePatch(clz = RunPathElement.class, method = SpirePatch.CLASS)
+    public static class ZoneField {
+        public static final SpireField<String> zone = new SpireField<>(() -> null);
+    }
+
+    @SpirePatch(clz = RunHistoryPath.class, method = "setRunData")
+    public static class AddZoneDataPatch {
+        @SuppressWarnings("rawtypes")
+        @SpireInsertPatch(locator = Locator.class, localvars = { "element", "i" })
+        public static void addZoneData(RunHistoryPath __instance, RunData newData, RunPathElement element, int i) throws NoSuchFieldException, IllegalAccessException {
+            Field field = newData.getClass().getField("zone_per_floor");
+            List zone_per_floor = (List)field.get(newData);
+            if (zone_per_floor != null && i < zone_per_floor.size()) {
+                Object zoneID = zone_per_floor.get(i);
+                String s = null;
+                if (zoneID instanceof String) {
+                    s = (String)zoneID;
+                }
+                else if (zoneID != null) {
+                    logger.warn("Unrecognized zone_per_floor data: " + zoneID);
+                }
+                ZoneField.zone.set(element, s);
+            }
+        }
+
+        public static class Locator extends SpireInsertLocator {
+            public int[] Locate(CtBehavior ctMethodToPatch) throws CannotCompileException, PatchingException {
+                Matcher matcher = new Matcher.NewExprMatcher(RunPathElement.class);
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(List.class, "add");
+                return LineFinder.findInOrder(ctMethodToPatch, Collections.singletonList(matcher), finalMatcher);
+            }
+        }
+    }
+
+    @SpirePatch(clz = RunPathElement.class, method = "getTipDescriptionText")
+    public static class DisplayZoneDataPatch {
+        @SpireInsertPatch(locator = Locator.class, localvars = { "sb" })
+        public static void displayZoneData(RunPathElement __instance, StringBuilder sb) {
+            String zoneID = ZoneField.zone.get(__instance);
+            if (zoneID != null) {
+                Optional<AbstractZone> zone = SpireAnniversary6Mod.unfilteredAllZones.stream().filter(z -> z.id.equals(zoneID)).findFirst();
+                if (sb.length() > 0) {
+                    sb.append(" NL ");
+                }
+                String zoneName = zoneID;
+                if (zone.isPresent()) {
+                    zoneName = zone.get().name;
+                }
+                sb.append(FontHelper.colorString(ZONE_TEXT.replace("{0}", zoneName), "b"));
+            }
+        }
+
+        public static class Locator extends SpireInsertLocator {
+            public int[] Locate(CtBehavior ctMethodToPatch) throws CannotCompileException, PatchingException {
+                Matcher matcher = new Matcher.FieldAccessMatcher(RunPathElement.class, "eventStats");
+                return LineFinder.findInOrder(ctMethodToPatch, matcher);
+            }
+        }
+    }
+
+    @SpirePatch(clz = AbstractDungeon.class, method = "incrementFloorBasedMetrics")
+    public static class ZonePerFloorAddLoggingPatch {
+        @SpirePostfixPatch
+        public static void incrementFloorBasedMetricsPatch(AbstractDungeon __instance) {
+            if (AbstractDungeon.floorNum != 0) {
+                AbstractZone zone = Wiz.getCurZone();
+                String zoneID = zone == null ? null : zone.id;
+                ZonePerFloorLog.zonePerFloorLog.add(zoneID);
+            }
+        }
+    }
+
+    @SpirePatch2(clz = AbstractDungeon.class, method = "generateSeeds")
+    public static class InitializeZonePerFloorPatch {
+        @SpirePostfixPatch
+        public static void initializeZonePerFloor() {
+            ZonePerFloorLog.zonePerFloorLog = new ArrayList<>();
+        }
+    }
+
+    public static class ZonePerFloorLog implements CustomSavable<ArrayList<String>> {
+        public final static String SaveKey = "ZonePerFloor";
+
+        public static ArrayList<String> zonePerFloorLog;
+
+        @Override
+        public ArrayList<String> onSave() {
+            return ZonePerFloorLog.zonePerFloorLog;
+        }
+
+        @Override
+        public void onLoad(ArrayList<String> list) {
+            ZonePerFloorLog.zonePerFloorLog = list != null ? list : new ArrayList<>();
+        }
+    }
+}

--- a/src/main/resources/anniv6Resources/localization/eng/UIstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/UIstrings.json
@@ -17,5 +17,10 @@
     "TEXT": [
       "Combat Modifier"
     ]
+  },
+  "${ModID}:RunHistoryScreen": {
+    "TEXT": [
+      "Zone: {0}"
+    ]
   }
 }


### PR DESCRIPTION
I like run history having information like this, so I went ahead and implemented it. The patch is adapted from the patches I've written for stuff like this in other mods. 

Here's how it looks right now:
![image](https://github.com/erasels/SpireMapOverhaul/assets/62083413/e230e649-c58a-461c-a4c0-c4323f91630a)
