### PR TITLE
Add a checkbox on the character select screen for turning zones on and off on a per-run basis

### DIFF
--- a/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
+++ b/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
@@ -78,6 +78,7 @@ public class SpireAnniversary6Mod implements
     public static SpireAnniversary6Mod thismod;
     public static SpireConfig modConfig = null;
     public static SpireConfig currentRunConfig = null;
+    public static boolean currentRunActive = false;
 
     public static final String modID = "anniv6";
 
@@ -144,7 +145,7 @@ public class SpireAnniversary6Mod implements
 
         try {
             Properties defaults = new Properties();
-            //defaults.put("Example", "FALSE");
+            defaults.put("active", true);
             modConfig = new SpireConfig(modID, "anniv6Config", defaults);
         } catch (Exception e) {
             e.printStackTrace();
@@ -239,6 +240,7 @@ public class SpireAnniversary6Mod implements
     }
 
     public static void addSaveFields() {
+        BaseMod.addSaveField(SavableCurrentRunActive.SaveKey, new SavableCurrentRunActive());
         BaseMod.addSaveField(ZonePerFloorRunHistoryPatch.ZonePerFloorLog.SaveKey, new ZonePerFloorRunHistoryPatch.ZonePerFloorLog());
         BaseMod.addSaveField(EncounterModifierPatches.LastZoneNormalEncounter.SaveKey, new EncounterModifierPatches.LastZoneNormalEncounter());
         BaseMod.addSaveField(EncounterModifierPatches.LastZoneEliteEncounter.SaveKey, new EncounterModifierPatches.LastZoneEliteEncounter());
@@ -613,6 +615,35 @@ public class SpireAnniversary6Mod implements
             currentRunConfig.save();
         } catch (IOException e) {
             e.printStackTrace();
+        }
+    }
+
+    public static class SavableCurrentRunActive implements CustomSavable<Boolean> {
+        public final static String SaveKey = "CurrentRunActive";
+
+        @Override
+        public Boolean onSave() {
+            return currentRunActive;
+        }
+
+        @Override
+        public void onLoad(Boolean b) {
+            currentRunActive = b == null ? true : b;
+        }
+    }
+
+    public static boolean getActiveConfig() {
+        return modConfig == null || modConfig.getBool("active");
+    }
+
+    public static void setActiveConfig(boolean active) {
+        if (modConfig != null) {
+            modConfig.setBool("active", active);
+            try {
+                modConfig.save();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/spireMapOverhaul/patches/BetterMapGenPatch.java
+++ b/src/main/java/spireMapOverhaul/patches/BetterMapGenPatch.java
@@ -7,6 +7,7 @@ import com.megacrit.cardcrawl.map.MapGenerator;
 import com.megacrit.cardcrawl.map.MapRoomNode;
 import com.megacrit.cardcrawl.random.Random;
 import spireMapOverhaul.BetterMapGenerator;
+import spireMapOverhaul.SpireAnniversary6Mod;
 
 import java.util.ArrayList;
 
@@ -19,7 +20,7 @@ public class BetterMapGenPatch {
 
     @SpirePrefixPatch
     public static SpireReturn<ArrayList<ArrayList<MapRoomNode>>> altGen(int height, int width, int pathDensity, Random rng) {
-        if (chance >= 1 || rng.copy().randomBoolean(chance)) { //Avoid affecting map gen if false
+        if (SpireAnniversary6Mod.currentRunActive && (chance >= 1 || rng.copy().randomBoolean(chance))) { //Avoid affecting map gen if false
             return SpireReturn.Return(BetterMapGenerator.generator.generate(rng, width, height, pathDensity));
         }
         return SpireReturn.Continue();

--- a/src/main/java/spireMapOverhaul/patches/CharacterSelectScreenPatch.java
+++ b/src/main/java/spireMapOverhaul/patches/CharacterSelectScreenPatch.java
@@ -1,0 +1,112 @@
+package spireMapOverhaul.patches;
+
+import basemod.ReflectionHacks;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch2;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.helpers.TipHelper;
+import com.megacrit.cardcrawl.helpers.controller.CInputActionSet;
+import com.megacrit.cardcrawl.helpers.input.InputHelper;
+import com.megacrit.cardcrawl.screens.charSelect.CharacterSelectScreen;
+import com.megacrit.cardcrawl.ui.panels.SeedPanel;
+import spireMapOverhaul.SpireAnniversary6Mod;
+
+public class CharacterSelectScreenPatch {
+    private static final String[] TEXT = CardCrawlGame.languagePack.getUIString(SpireAnniversary6Mod.makeID("CharacterSelectScreen")).TEXT;
+
+    private static float getSpacing() {
+        float ascensionLevelTextWidth = ReflectionHacks.getPrivateStatic(CharacterSelectScreen.class, "ASC_RIGHT_W");
+        return 255.0F * Settings.scale + ascensionLevelTextWidth;
+    }
+
+    private static float getCheckboxX() {
+        return (float) Settings.WIDTH / 2.0F + getSpacing() + 16.0F;
+    }
+
+    private static float getTextWidth() {
+        return FontHelper.getSmartWidth(FontHelper.cardTitleFont, TEXT[0], 9999.0F, 0.0F);
+    }
+
+    @SpirePatch(clz = CharacterSelectScreen.class, method = SpirePatch.CLASS)
+    public static class HitboxField {
+        public static final SpireField<Hitbox> hitbox = new SpireField<>(() -> null);
+    }
+
+    @SpirePatch(clz = CharacterSelectScreen.class, method = "initialize")
+    public static class InitializeHitboxPatch {
+        @SpirePostfixPatch
+        public static void initializeHitbox(CharacterSelectScreen __instance) {
+            float textWidth = FontHelper.getSmartWidth(FontHelper.cardTitleFont, TEXT[0], 9999.0F, 0.0F);
+            float checkBoxX = getCheckboxX();
+            float hitboxX = checkBoxX + 30.0F * Settings.scale / 2.0F + textWidth / 2.0F + 16.0F;
+            Hitbox hitbox = new Hitbox(textWidth + 70.0F * Settings.scale, 35.0F * Settings.scale);
+            hitbox.move(hitboxX, 35.0F * Settings.scale);
+            HitboxField.hitbox.set(__instance, hitbox);
+        }
+    }
+
+    @SpirePatch(clz = CharacterSelectScreen.class, method = "renderAscensionMode")
+    public static class RenderCheckboxPatch {
+        @SpirePostfixPatch
+        public static void renderCheckbox(CharacterSelectScreen __instance, SpriteBatch sb, boolean ___anySelected) {
+            if (___anySelected) {
+                Hitbox hb = HitboxField.hitbox.get(__instance);
+                float checkBoxX = getCheckboxX();
+                sb.draw(ImageMaster.OPTION_TOGGLE, checkBoxX, hb.cY - 16.0F, 16.0F, 16.0F, 32.0F, 32.0F, Settings.scale, Settings.scale, 0.0F, 0, 0, 32, 32, false, false);
+
+                FontHelper.renderFontCentered(sb, FontHelper.cardTitleFont, TEXT[0], checkBoxX + 30.0F * Settings.scale + getTextWidth() / 2.0F + 16.0F, hb.cY, hb.hovered ? new Color(-2016482305) : new Color(1097458175));
+                if (hb.hovered) {
+                    TipHelper.renderGenericTip((float) InputHelper.mX - 140.0F * Settings.scale, (float) InputHelper.mY + 340.0F * Settings.scale, TEXT[0], TEXT[1]);
+                }
+
+                if (SpireAnniversary6Mod.getActiveConfig()) {
+                    sb.setColor(Color.WHITE);
+                    sb.draw(ImageMaster.OPTION_TOGGLE_ON, checkBoxX, hb.cY - 16.0F, 16.0F, 16.0F, 32.0F, 32.0F, Settings.scale, Settings.scale, 0.0F, 0, 0, 32, 32, false, false);
+                }
+
+                hb.render(sb);
+            }
+        }
+    }
+
+    @SpirePatch(clz = CharacterSelectScreen.class, method = "updateAscensionToggle")
+    public static class UpdateCheckboxPatch {
+        @SpirePostfixPatch
+        public static void updateCheckbox(CharacterSelectScreen __instance, SeedPanel ___seedPanel, boolean ___anySelected) {
+            if (!___anySelected) {
+                return;
+            }
+
+            Hitbox hb = HitboxField.hitbox.get(__instance);
+            hb.update();
+
+            if (InputHelper.justClickedLeft) {
+                if (hb.hovered) {
+                    hb.clickStarted = true;
+                }
+            }
+
+            if (hb.clicked || CInputActionSet.proceed.isJustPressed()) {
+                hb.clicked = false;
+                SpireAnniversary6Mod.setActiveConfig(!SpireAnniversary6Mod.getActiveConfig());
+            }
+        }
+    }
+
+    @SpirePatch2(clz = AbstractDungeon.class, method = "generateSeeds")
+    public static class InitializeCurrentRunActivePatch {
+        @SpirePostfixPatch
+        public static void initializeCurrentRunActivePatch() {
+            SpireAnniversary6Mod.currentRunActive = SpireAnniversary6Mod.getActiveConfig();
+        }
+    }
+}

--- a/src/main/resources/anniv6Resources/localization/eng/UIstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/UIstrings.json
@@ -22,5 +22,11 @@
     "TEXT": [
       "Zone: {0}"
     ]
+  },
+  "${ModID}:CharacterSelectScreen": {
+    "TEXT": [
+      "Zones",
+      "Adds zones to the Spire, which change parts of the map to have new content."
+    ]
   }
 }


### PR DESCRIPTION
I don't remember if I mentioned this or not, but one thought I had for this project was to let people turn the entire zone system on or off on a per-run basis.

The root of this idea comes from my experience with Corrupt the Spire. Some players gave the feedback that they liked the mod, but didn't always want to play with it, and also didn't want to relaunch Slay the Spire just to turn it on or off. Players in that situation may end up turning the mod off for good if they think it's too much trouble. To counteract that, I added a checkbox on the character select screen that turns Corrupt the Spire on or off.

What we're doing with zones feels pretty similar to me, so I wanted to try out having a similar checkbox. The image below shows how this looks (to the right of the ascension level selector). I've included the Corrupt the Spire checkbox in the image for comparison purposes.
![image](https://github.com/erasels/SpireMapOverhaul/assets/62083413/7cc86e04-60ef-456b-b366-6d720d168e2a)

The state of the checkbox is remembered via the mod's config, and whether zones are active for a given run is locked in when you start the run.