### PR TITLE
Fix zone outline shader not rendering on Mac.

### DIFF
--- a/src/main/java/spireMapOverhaul/util/ZoneShapeMaker.java
+++ b/src/main/java/spireMapOverhaul/util/ZoneShapeMaker.java
@@ -453,4 +453,10 @@ public class ZoneShapeMaker {
     public void receiveImGui() {
         if (AbstractDungeon.isPlayerInDungeon()) makeImgui();
     }
+
+    static {
+        if (!shader.isCompiled()) {
+            SpireAnniversary6Mod.logger.error("Shader compilation failed: " + shader.getLog());
+        }
+    }
 }

--- a/src/main/resources/anniv6Resources/shaders/shapeMaker/fragment.fs
+++ b/src/main/resources/anniv6Resources/shaders/shapeMaker/fragment.fs
@@ -1,7 +1,5 @@
 //---------------------------------------------------------------------------
-
-
-in vec2 pos;                    // screen position <-1,+1>
+varying vec2 pos;                    // screen position <-1,+1>
                                 // fragment output color
 uniform sampler2D txr;          // texture to blu
 

--- a/src/main/resources/anniv6Resources/shaders/shapeMaker/vertex.vs
+++ b/src/main/resources/anniv6Resources/shaders/shapeMaker/vertex.vs
@@ -1,16 +1,15 @@
-#version 330
-
 uniform mat4 u_projTrans;
 
-in vec4 a_position;
-in vec2 a_texCoord0;
-in vec4 a_color;
+attribute vec4 a_position;
+attribute vec2 a_texCoord0;
+attribute vec4 a_color;
 
-out vec4 v_color;
-out vec2 pos;
+varying vec4 v_color;
+varying vec2 pos;
 
 void main() {
     gl_Position = u_projTrans * a_position;
     v_color = a_color;
     pos = a_texCoord0;
 }
+


### PR DESCRIPTION
This may need some testing on Windows and Linux, but this should fix an issue where zone outlines do not render when on a Mac. If needed, we may have to add some way to swap between shaders depending on platform. for now I'm hoping this will work out of the box, and I'll be able to test it soon. Also added a log for the shader just in case we run into an issue like this again. 
![image](https://github.com/erasels/SpireMapOverhaul/assets/54343976/b28dd739-b6d6-4f18-b5a9-83f6d364e55d)
