### PR TITLE
fix: Various Lightning Fixes

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
@@ -53,6 +53,7 @@ public class StormZone extends AbstractZone implements CombatModifyingZone, Rewa
     }
 
     public void onEnterRoom() {
+        conduitTarget = null;
         if(StormUtil.rainSoundId == 0L) {
             StormUtil.rainSoundId = CardCrawlGame.sound.playAndLoop(RAIN_KEY);
         }
@@ -60,6 +61,7 @@ public class StormZone extends AbstractZone implements CombatModifyingZone, Rewa
     public void onExit() {
         CardCrawlGame.sound.stop(RAIN_KEY, StormUtil.rainSoundId);
         StormUtil.rainSoundId = 0L;
+        conduitTarget = null;
     }
 
     @Override

--- a/src/main/java/spireMapOverhaul/zones/storm/patches/AddLightningPatch.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/patches/AddLightningPatch.java
@@ -55,10 +55,10 @@ public class AddLightningPatch {
 
                         vfxTimer = MathUtils.random(timeScaleStart, timeScaleEnd);
                         if(!AbstractDungeon.actionManager.turnHasEnded) {
-                            timeScaleStart = 0.1f;
-                            timeScaleEnd = 0.3f;
+                            timeScaleStart = 0.7f;
+                            timeScaleEnd = 1.0f;
                         } else {
-                            vfxTimer = 0.01f;
+                            vfxTimer = 0.1f;
                         }
                     }
                 }

--- a/src/main/java/spireMapOverhaul/zones/storm/powers/ConduitPower.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/powers/ConduitPower.java
@@ -16,6 +16,7 @@ import com.megacrit.cardcrawl.helpers.FontHelper;
 import com.megacrit.cardcrawl.localization.PowerStrings;
 import com.megacrit.cardcrawl.vfx.combat.LightningEffect;
 import spireMapOverhaul.abstracts.AbstractSMOPower;
+import spireMapOverhaul.zones.storm.StormUtil;
 import spireMapOverhaul.zones.storm.StormZone;
 
 import static spireMapOverhaul.SpireAnniversary6Mod.makeID;
@@ -39,11 +40,17 @@ public class ConduitPower extends AbstractSMOPower {
     }
 
     @Override
-    public void atEndOfRound() {
+    public void atEndOfTurn(boolean isPlayer) {
         atb(new VFXAction(new LightningEffect(owner.drawX, owner.drawY)));
         atb(new RemoveSpecificPowerAction(owner, owner, this));
         atb(new DamageAction(owner, new DamageInfo(null, amount, DamageInfo.DamageType.THORNS), AbstractGameAction.AttackEffect.NONE, true));
         atb(new SFXAction("ORB_LIGHTNING_EVOKE"));
+        StormUtil.conduitTarget = null;
+    }
+
+    @Override
+    public void onDeath() {
+        StormUtil.conduitTarget = null;
     }
 
     @Override

--- a/src/main/java/spireMapOverhaul/zones/storm/vfx/AlwaysBehindLightningEffect.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/vfx/AlwaysBehindLightningEffect.java
@@ -53,4 +53,12 @@ public class AlwaysBehindLightningEffect extends AbstractGameEffect {
     }
 
     public void dispose() {}
+
+    public float[] _lightsOutGetXYRI() {
+        return new float[] {x, y, 400f*Settings.scale, 0.8f};
+    }
+
+    public Color[] _lightsOutGetColor() {
+        return new Color[] {Color.WHITE};
+    }
 }

--- a/src/main/java/spireMapOverhaul/zones/storm/vfx/DispelPlayerElectricEffect.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/vfx/DispelPlayerElectricEffect.java
@@ -1,7 +1,9 @@
 package spireMapOverhaul.zones.storm.vfx;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.vfx.AbstractGameEffect;
 import com.megacrit.cardcrawl.vfx.combat.EmptyStanceParticleEffect;
@@ -34,4 +36,12 @@ public class DispelPlayerElectricEffect extends AbstractGameEffect {
     public void render(SpriteBatch sb) {}
 
     public void dispose() {}
+
+    public float[] _lightsOutGetXYRI() {
+        return new float[] {x, y, 150f* Settings.scale, 1.0f};
+    }
+
+    public Color[] _lightsOutGetColor() {
+        return new Color[] {Color.CYAN};
+    }
 }

--- a/src/main/resources/anniv6Resources/localization/eng/Storm/Powerstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/Storm/Powerstrings.json
@@ -1,6 +1,6 @@
 {
   "${ModID}:ConduitPower": {
     "NAME": "Conduit",
-    "DESCRIPTIONS": ["Target will receive #b", " blockable damage at the end of the enemy turn."]
+    "DESCRIPTIONS": ["At the end its turn, the target will take #b", " blockable damage."]
   }
 }


### PR DESCRIPTION
- Conduit triggers at the end of the target's turn. Player's block was disappating before the trigger at end of round
- Fix bug where the spark vfx could trigger on non-existent targets, both dead and in a new room
- Added LightOut support for lightning background vfx
- Made the Conduit spark vfx happen less frequently