### PR TITLE
Prevent zones from showing up more than once in a run

### DIFF
--- a/src/main/java/spireMapOverhaul/BetterMapGenerator.java
+++ b/src/main/java/spireMapOverhaul/BetterMapGenerator.java
@@ -11,6 +11,7 @@ import spireMapOverhaul.patches.ZonePatches;
 
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class BetterMapGenerator {
     public static final Logger mapGenLogger = LogManager.getLogger("BetterMapGen");
@@ -36,12 +37,16 @@ public class BetterMapGenerator {
     }
 
     public ArrayList<ArrayList<MapRoomNode>> generate(Random rng, int width, int height, int pathDensity) {
+        SpireAnniversary6Mod.currentRunSeenZones.addAll(activeZones.stream().map(z -> z.id).collect(Collectors.toList()));
+        mapGenLogger.info("Already seen zones: " + String.join(",", SpireAnniversary6Mod.currentRunSeenZones));
         MapPlanner planner;
         do {
             List<AbstractZone> possibleZones = new ArrayList<>();
-            for (AbstractZone zone : SpireAnniversary6Mod.allZones)
-                if (zone.canSpawn())
+            for (AbstractZone zone : SpireAnniversary6Mod.unfilteredAllZones) {
+                if (SpireAnniversary6Mod.currentRunAllZones.contains(zone.id) && !SpireAnniversary6Mod.currentRunSeenZones.contains(zone.id) && zone.canSpawn()) {
                     possibleZones.add(zone);
+                }
+            }
 
             planner = new MapPlanner(width, height);
 

--- a/src/main/java/spireMapOverhaul/BetterMapGenerator.java
+++ b/src/main/java/spireMapOverhaul/BetterMapGenerator.java
@@ -51,7 +51,7 @@ public class BetterMapGenerator {
         do {
             List<AbstractZone> possibleZones = new ArrayList<>();
             for (AbstractZone zone : SpireAnniversary6Mod.unfilteredAllZones) {
-                if (SpireAnniversary6Mod.currentRunAllZones.contains(zone.id) && !SpireAnniversary6Mod.currentRunSeenZones.contains(zone.id) && zone.canSpawn()) {
+                if (SpireAnniversary6Mod.currentRunAllZones.contains(zone.id) && !(SpireAnniversary6Mod.currentRunNoRepeatZones && SpireAnniversary6Mod.currentRunSeenZones.contains(zone.id)) && zone.canSpawn()) {
                     possibleZones.add(zone);
                 }
             }

--- a/src/main/java/spireMapOverhaul/BetterMapGenerator.java
+++ b/src/main/java/spireMapOverhaul/BetterMapGenerator.java
@@ -1,6 +1,7 @@
 package spireMapOverhaul;
 
 import com.badlogic.gdx.math.MathUtils;
+import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.map.MapEdge;
 import com.megacrit.cardcrawl.map.MapRoomNode;
 import com.megacrit.cardcrawl.random.Random;
@@ -8,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import spireMapOverhaul.abstracts.AbstractZone;
 import spireMapOverhaul.patches.ZonePatches;
+import spireMapOverhaul.util.ActUtil;
 
 import java.util.*;
 import java.util.function.Predicate;
@@ -37,7 +39,13 @@ public class BetterMapGenerator {
     }
 
     public ArrayList<ArrayList<MapRoomNode>> generate(Random rng, int width, int height, int pathDensity) {
-        SpireAnniversary6Mod.currentRunSeenZones.addAll(activeZones.stream().map(z -> z.id).collect(Collectors.toList()));
+        if (Settings.isEndless && ActUtil.getRealActNum() == 1) {
+            //In endless mode, we let you encounter zones again each endless cycle
+            SpireAnniversary6Mod.currentRunSeenZones.clear();
+        }
+        else {
+            SpireAnniversary6Mod.currentRunSeenZones.addAll(activeZones.stream().map(z -> z.id).collect(Collectors.toList()));
+        }
         mapGenLogger.info("Already seen zones: " + String.join(",", SpireAnniversary6Mod.currentRunSeenZones));
         MapPlanner planner;
         do {

--- a/src/main/java/spireMapOverhaul/BetterMapGenerator.java
+++ b/src/main/java/spireMapOverhaul/BetterMapGenerator.java
@@ -35,6 +35,13 @@ public class BetterMapGenerator {
         return activeZones;
     }
 
+    public static void clearActiveZones() {
+        for (AbstractZone z : activeZones) {
+            z.dispose();
+        }
+        activeZones.clear();
+    }
+
     private BetterMapGenerator() {
     }
 
@@ -59,10 +66,7 @@ public class BetterMapGenerator {
             planner = new MapPlanner(width, height);
 
             AbstractZone zone;
-            for (AbstractZone z : activeZones) {
-                z.dispose();
-            }
-            activeZones.clear();
+            clearActiveZones();
             float zoneRate = 1;
 
             for (AbstractZone queuedZone : queueCommandZones) {

--- a/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
+++ b/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
@@ -106,6 +106,7 @@ public class SpireAnniversary6Mod implements
     public static SpireAnniversary6Mod thismod;
     public static SpireConfig modConfig = null;
     public static boolean currentRunActive = false;
+    public static boolean currentRunNoRepeatZones = false;
     public static HashSet<String> currentRunAllZones = null;
     public static HashSet<String> currentRunSeenZones = null;
 
@@ -178,6 +179,7 @@ public class SpireAnniversary6Mod implements
         try {
             Properties defaults = new Properties();
             defaults.put("active", "TRUE");
+            defaults.put("noRepeatZones", "TRUE");
             defaults.put("largeIconsMode", "FALSE");
             modConfig = new SpireConfig(modID, "anniv6Config", defaults);
         } catch (Exception e) {
@@ -272,6 +274,7 @@ public class SpireAnniversary6Mod implements
 
     public static void addSaveFields() {
         BaseMod.addSaveField(SavableCurrentRunActive.SaveKey, new SavableCurrentRunActive());
+        BaseMod.addSaveField(SavableCurrentRunNoRepeatZones.SaveKey, new SavableCurrentRunNoRepeatZones());
         BaseMod.addSaveField(SavableCurrentRunAllZones.SaveKey, new SavableCurrentRunAllZones());
         BaseMod.addSaveField(SavableCurrentRunSeenZones.SaveKey, new SavableCurrentRunSeenZones());
         BaseMod.addSaveField(ZonePerFloorRunHistoryPatch.ZonePerFloorLog.SaveKey, new ZonePerFloorRunHistoryPatch.ZonePerFloorLog());
@@ -569,6 +572,8 @@ public class SpireAnniversary6Mod implements
     }
 
     private ModPanel settingsPanel;
+    private static final float NOREPEATZONES_CHECKBOX_X = 400f;
+    private static final float NOREPEATZONES_CHECKBOX_Y = 685f;
     private static final float LARGEICONS_CHECKBOX_X = 400f;
     private static final float LARGEICONS_CHECKBOX_Y = 650f;
     private DropdownMenu filterDropdown;
@@ -587,6 +592,11 @@ public class SpireAnniversary6Mod implements
         Texture badge = TexLoader.getTexture(makeImagePath("ui/badge.png"));
 
         settingsPanel = new ModPanel();
+
+        ModLabeledToggleButton noRepeatZonesToggle = new ModLabeledToggleButton(configStrings.TEXT[5], NOREPEATZONES_CHECKBOX_X, NOREPEATZONES_CHECKBOX_Y, Color.WHITE, FontHelper.tipBodyFont, getNoRepeatZonesConfig(), null,
+                (label) -> {},
+                (button) -> setNoRepeatZonesConfig(button.enabled));
+        settingsPanel.addUIElement(noRepeatZonesToggle);
 
         ModLabeledToggleButton largeIconsModeToggle = new ModLabeledToggleButton(configStrings.TEXT[4], LARGEICONS_CHECKBOX_X, LARGEICONS_CHECKBOX_Y, Color.WHITE, FontHelper.tipBodyFont, getLargeIconsModeConfig(), null,
                 (label) -> {},
@@ -688,6 +698,20 @@ public class SpireAnniversary6Mod implements
         }
     }
 
+    public static class SavableCurrentRunNoRepeatZones implements CustomSavable<Boolean> {
+        public final static String SaveKey = "CurrentRunNoRepeatZones";
+
+        @Override
+        public Boolean onSave() {
+            return currentRunNoRepeatZones;
+        }
+
+        @Override
+        public void onLoad(Boolean b) {
+            currentRunNoRepeatZones = b == null || b;
+        }
+    }
+
     public static class SavableCurrentRunAllZones implements CustomSavable<HashSet<String>> {
         public final static String SaveKey = "CurrentRunAllZones";
 
@@ -723,6 +747,21 @@ public class SpireAnniversary6Mod implements
     public static void setActiveConfig(boolean active) {
         if (modConfig != null) {
             modConfig.setBool("active", active);
+            try {
+                modConfig.save();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public static boolean getNoRepeatZonesConfig() {
+        return modConfig != null && modConfig.getBool("noRepeatZones");
+    }
+
+    public static void setNoRepeatZonesConfig(boolean bool) {
+        if (modConfig != null) {
+            modConfig.setBool("noRepeatZones", bool);
             try {
                 modConfig.save();
             } catch (IOException e) {

--- a/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
+++ b/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
@@ -673,7 +673,10 @@ public class SpireAnniversary6Mod implements
 
     @Override
     public void receiveStartGame() {
-        if (!CardCrawlGame.loadingSave) {
+        if (CardCrawlGame.loadingSave) {
+            // Clean up any zones from before the save and load
+            BetterMapGenerator.clearActiveZones();
+        } else {
             BeastsLairZone.clearBossList();
         }
     }

--- a/src/main/java/spireMapOverhaul/patches/CharacterSelectScreenPatch.java
+++ b/src/main/java/spireMapOverhaul/patches/CharacterSelectScreenPatch.java
@@ -101,12 +101,4 @@ public class CharacterSelectScreenPatch {
             }
         }
     }
-
-    @SpirePatch2(clz = AbstractDungeon.class, method = "generateSeeds")
-    public static class InitializeCurrentRunActivePatch {
-        @SpirePostfixPatch
-        public static void initializeCurrentRunActivePatch() {
-            SpireAnniversary6Mod.currentRunActive = SpireAnniversary6Mod.getActiveConfig();
-        }
-    }
 }

--- a/src/main/java/spireMapOverhaul/patches/InitializeCurrentRunPatch.java
+++ b/src/main/java/spireMapOverhaul/patches/InitializeCurrentRunPatch.java
@@ -1,0 +1,23 @@
+package spireMapOverhaul.patches;
+
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch2;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import spireMapOverhaul.SpireAnniversary6Mod;
+
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
+@SpirePatch2(clz = AbstractDungeon.class, method = "generateSeeds")
+public class InitializeCurrentRunPatch {
+    @SpirePostfixPatch
+    public static void initializeCurrentRun() {
+        SpireAnniversary6Mod.currentRunActive = SpireAnniversary6Mod.getActiveConfig();
+        SpireAnniversary6Mod.currentRunAllZones = SpireAnniversary6Mod.unfilteredAllZones.stream()
+                .map(z -> z.id)
+                .filter(SpireAnniversary6Mod::getFilterConfig)
+                .collect(Collectors.toCollection(HashSet::new));
+        SpireAnniversary6Mod.currentRunSeenZones = new HashSet<>();
+    }
+}

--- a/src/main/java/spireMapOverhaul/patches/InitializeCurrentRunPatch.java
+++ b/src/main/java/spireMapOverhaul/patches/InitializeCurrentRunPatch.java
@@ -14,6 +14,7 @@ public class InitializeCurrentRunPatch {
     @SpirePostfixPatch
     public static void initializeCurrentRun() {
         SpireAnniversary6Mod.currentRunActive = SpireAnniversary6Mod.getActiveConfig();
+        SpireAnniversary6Mod.currentRunNoRepeatZones = SpireAnniversary6Mod.getNoRepeatZonesConfig();
         SpireAnniversary6Mod.currentRunAllZones = SpireAnniversary6Mod.unfilteredAllZones.stream()
                 .map(z -> z.id)
                 .filter(SpireAnniversary6Mod::getFilterConfig)

--- a/src/main/java/spireMapOverhaul/util/ActUtil.java
+++ b/src/main/java/spireMapOverhaul/util/ActUtil.java
@@ -31,9 +31,10 @@ public class ActUtil {
                 case TheBeyond.ID:
                     return 3;
                 case TheEnding.ID:
+                case "EYB:TheUnnamedReign":
                     return 4;
                 default:
-                    throw new RuntimeException("Unrecognized act ID: " + AbstractDungeon.id + ". When ActLikeIt isn't loaded, the only possible acts should be the vanilla four and The Jungle.");
+                    throw new RuntimeException("Unrecognized act ID: " + AbstractDungeon.id + ". When ActLikeIt isn't loaded, the only possible acts should be the vanilla four and a few special cases.");
             }
         }
     }

--- a/src/main/java/spireMapOverhaul/util/ActUtil.java
+++ b/src/main/java/spireMapOverhaul/util/ActUtil.java
@@ -1,11 +1,40 @@
 package spireMapOverhaul.util;
 
+import com.evacipated.cardcrawl.modthespire.Loader;
 import com.megacrit.cardcrawl.core.Settings;
-import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.dungeons.*;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class ActUtil {
     public static int getRealActNum() {
-        if (Settings.isEndless) return AbstractDungeon.actNum % 3;
-        return AbstractDungeon.actNum;
+        if (Loader.isModLoaded("actlikeit")) {
+            // If ActLikeIt is loaded, it has the real act number for us
+            try {
+                Class<?> clz = Class.forName("actlikeit.savefields.BehindTheScenesActNum");
+                Method m = clz.getMethod("getActNum");
+                return (int)m.invoke(null);
+            } catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
+                e.printStackTrace();
+                throw new RuntimeException("Failed when trying to call BehindTheScenesActNum.getActNum()", e);
+            }
+        }
+        else {
+            // If ActLikeIt isn't loaded, we can safely enumerate the possible acts and use that to determine the real act number
+            switch (AbstractDungeon.id) {
+                case Exordium.ID:
+                    return 1;
+                case TheCity.ID:
+                case "theJungle:Jungle":
+                    return 2;
+                case TheBeyond.ID:
+                    return 3;
+                case TheEnding.ID:
+                    return 4;
+                default:
+                    throw new RuntimeException("Unrecognized act ID: " + AbstractDungeon.id + ". When ActLikeIt isn't loaded, the only possible acts should be the vanilla four and The Jungle.");
+            }
+        }
     }
 }

--- a/src/main/java/spireMapOverhaul/util/ActUtil.java
+++ b/src/main/java/spireMapOverhaul/util/ActUtil.java
@@ -3,6 +3,7 @@ package spireMapOverhaul.util;
 import com.evacipated.cardcrawl.modthespire.Loader;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.*;
+import spireMapOverhaul.SpireAnniversary6Mod;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -34,7 +35,11 @@ public class ActUtil {
                 case "EYB:TheUnnamedReign":
                     return 4;
                 default:
-                    throw new RuntimeException("Unrecognized act ID: " + AbstractDungeon.id + ". When ActLikeIt isn't loaded, the only possible acts should be the vanilla four and a few special cases.");
+                    SpireAnniversary6Mod.logger.error("Unrecognized act ID: " + AbstractDungeon.id + ". When ActLikeIt isn't loaded, the only possible acts should be the vanilla four and a few special cases.");
+                    // We could throw an exception here, but to be a bit more robust just in case there's some other
+                    // strange act out there, we instead arbitrarily treat them as act 4s. The worst this will do is
+                    // make some zones not spawn or fall back to non-zone monster encounters
+                    return 4;
             }
         }
     }

--- a/src/main/resources/anniv6Resources/localization/eng/UIstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/UIstrings.json
@@ -5,7 +5,8 @@
       "StS Modding Community",
       "Makes the map more interesting.",
       "Enabled",
-      "Make zone icons larger but cut off by the zone's shape."
+      "Make zone icons larger but cut off by the zone's shape.",
+      "Don't repeat zones during a run."
     ]
   },
   "${ModID}:SingleCardReward": {


### PR DESCRIPTION
I took a bit of time to implement this since even if we end up not wanting it in the full release, I think it's a good thing to have in place for playtesting. (I certainly want it for my own playtesting, at the very least.)

We can discuss exactly how we want to merge this -- as is, or with some kind of setting or config option or console command for it, or some other option. I do want to get some version of these changes merged in, though, since it has a better system for recording which zones are valid for your current run (using a savable instead of a config).