### PR TITLE
Fix forced events not being added to seenEvents

### DIFF
--- a/src/main/java/spireMapOverhaul/patches/EventGenPatch.java
+++ b/src/main/java/spireMapOverhaul/patches/EventGenPatch.java
@@ -1,8 +1,12 @@
 package spireMapOverhaul.patches;
 
+import basemod.ReflectionHacks;
+import basemod.eventUtil.EventUtils;
+import basemod.patches.com.megacrit.cardcrawl.characters.AbstractPlayer.SeenEvents;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.events.AbstractEvent;
+import com.megacrit.cardcrawl.helpers.EventHelper;
 import com.megacrit.cardcrawl.random.Random;
 import javassist.CtBehavior;
 import spireMapOverhaul.SpireAnniversary6Mod;
@@ -10,6 +14,7 @@ import spireMapOverhaul.abstracts.AbstractZone;
 import spireMapOverhaul.zoneInterfaces.ModifiedEventRateZone;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Set;
 
 public class EventGenPatch {
@@ -22,8 +27,20 @@ public class EventGenPatch {
         public static SpireReturn<AbstractEvent> modifyGen(Random rng) {
             AbstractZone current = ZonePatches.currentZone();
             if (current instanceof ModifiedEventRateZone) {
-                AbstractEvent ret = ((ModifiedEventRateZone) current).forceEvent();
-                if (ret != null) return SpireReturn.Return(ret);
+                String retID = ((ModifiedEventRateZone) current).forceEvent();
+                if (retID != null) {
+                    HashSet<String> seenEvents = SeenEvents.seenEvents.get(AbstractDungeon.player);
+                    AbstractEvent e = EventUtils.getEvent(retID);
+                    if (e == null) {
+                        e = EventHelper.getEvent(retID);
+                    }
+                    if(e != null) {
+                        seenEvents.add(retID);
+                        return SpireReturn.Return(e);
+                    } else {
+                        SpireAnniversary6Mod.logger.error("Failed to get event " + retID);
+                    }
+                }
 
                 Set<String> zoneEvents = SpireAnniversary6Mod.zoneEvents.get(current.id);
                 if (zoneEvents == null || zoneEvents.isEmpty() || AbstractDungeon.eventList.isEmpty())
@@ -31,7 +48,7 @@ public class EventGenPatch {
 
                 if (rng.randomBoolean(((ModifiedEventRateZone) current).zoneSpecificEventRate())) {
                     RigRoll.validEvents = zoneEvents;
-                    ret = AbstractDungeon.getEvent(rng);
+                    AbstractEvent ret = AbstractDungeon.getEvent(rng);
                     RigRoll.validEvents = null;
                     return SpireReturn.Return(ret);
                 }

--- a/src/main/java/spireMapOverhaul/zoneInterfaces/ModifiedEventRateZone.java
+++ b/src/main/java/spireMapOverhaul/zoneInterfaces/ModifiedEventRateZone.java
@@ -11,18 +11,15 @@ public interface ModifiedEventRateZone {
     /**
      * @return If not null, forces the event rolled to be this. Recommended to use with y-position based checks,
      */
-    default AbstractEvent forceEvent() { return null; }
+    default String forceEvent() { return null; }
 
-    static AbstractEvent returnIfUnseen(String ID) {
+    static String returnIfUnseen(String ID) {
         if (!SeenEvents.seenEvents.get(AbstractDungeon.player).contains(ID)) {
-            AbstractEvent e = EventUtils.getEvent(ID);
-            if (e == null) {
-                e = EventHelper.getEvent(ID);
-                if (e == null) {
-                    SpireAnniversary6Mod.logger.info("Failed to get event " + ID);
-                }
+            if(!EventUtils.eventIDs.contains(ID)) {
+                SpireAnniversary6Mod.logger.error("Failed to find event " + ID);
+            } else {
+                return ID;
             }
-            return e;
         }
         return null;
     }

--- a/src/main/java/spireMapOverhaul/zones/example/PlaceholderZone.java
+++ b/src/main/java/spireMapOverhaul/zones/example/PlaceholderZone.java
@@ -32,7 +32,7 @@ public class PlaceholderZone extends AbstractZone implements ModifiedEventRateZo
     private final Color color;
 
     @Override
-    public AbstractEvent forceEvent() {
+    public String forceEvent() {
         return ModifiedEventRateZone.returnIfUnseen(CoolExampleEvent.ID);
     }
 

--- a/src/main/java/spireMapOverhaul/zones/manasurge/ManaSurgeZone.java
+++ b/src/main/java/spireMapOverhaul/zones/manasurge/ManaSurgeZone.java
@@ -236,7 +236,7 @@ public class ManaSurgeZone extends AbstractZone implements
     }
 
     @Override
-    public AbstractEvent forceEvent() {
+    public String forceEvent() {
         return ModifiedEventRateZone.returnIfUnseen(ManaCycloneEvent.ID);
     }
 


### PR DESCRIPTION
It seems that forced events don't get added to SeenEvents.seenEvents spirefield on AbstractPlayer. It happens due to getEvent never being called if we force an event.

To fix this, I manually add it in the `modifyGen` patch, however getting the correct event ID was hard in that place so I rewrote some code so that we're working with IDs for the most part.