### PR TITLE
Grass zone fixes

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/grass/GrassZone.java
+++ b/src/main/java/spireMapOverhaul/zones/grass/GrassZone.java
@@ -113,6 +113,7 @@ public class GrassZone extends AbstractZone implements CombatModifyingZone, Rend
                             && (relicPool == null || relicPool.contains(relicID))
                             && AbstractDungeon.relicRng.randomBoolean(getRelicChance())) {
                         rewardItem.relic = newRelic.makeCopy();
+                        rewardItem.text = newRelic.name;
                         // Add the old relic back in to the pool so that it can spawn again
                         Wiz.addRelicToPool(origRelic);
                         break;

--- a/src/main/java/spireMapOverhaul/zones/grass/actions/ThrowVegetableEffect.java
+++ b/src/main/java/spireMapOverhaul/zones/grass/actions/ThrowVegetableEffect.java
@@ -21,6 +21,7 @@ import spireMapOverhaul.zones.grass.vegetables.AbstractVegetableData;
 import java.util.ArrayList;
 
 public class ThrowVegetableEffect extends AbstractGameEffect {
+    private static final int MAX_POS = 10;
     private static Texture img;
     private final ArrayList<Vector2> previousPos = new ArrayList<>();
     private final float sX;
@@ -30,6 +31,7 @@ public class ThrowVegetableEffect extends AbstractGameEffect {
     private final float bounceHeight;
     private float cX;
     private float cY;
+    private float vR;
     private float yOffset;
     private boolean playedSfx = false;
 
@@ -50,6 +52,12 @@ public class ThrowVegetableEffect extends AbstractGameEffect {
         } else {
             this.bounceHeight = this.dY - this.sY + vegetable.data.bounce * Settings.scale;
         }
+        if (this.dX > this.sX) {
+            this.vR = -vegetable.data.rotation;
+        }
+        else {
+            this.vR = vegetable.data.rotation;
+        }
     }
 
     public void update() {
@@ -61,15 +69,11 @@ public class ThrowVegetableEffect extends AbstractGameEffect {
         this.cX = Interpolation.linear.apply(this.dX, this.sX, this.duration / 0.6F);
         this.cY = Interpolation.linear.apply(this.dY, this.sY, this.duration / 0.6F);
         this.previousPos.add(new Vector2(this.cX, this.cY + + this.yOffset));
-        if (this.previousPos.size() > 20) {
+        if (this.previousPos.size() > MAX_POS) {
             this.previousPos.remove(this.previousPos.get(0));
         }
 
-        if (this.dX > this.sX) {
-            this.rotation -= Gdx.graphics.getDeltaTime() * 1000.0F;
-        } else {
-            this.rotation += Gdx.graphics.getDeltaTime() * 1000.0F;
-        }
+        this.rotation += Gdx.graphics.getDeltaTime() * vR;
 
         if (this.duration > 0.3F) {
             this.yOffset = Interpolation.circleIn.apply(this.bounceHeight, 0.0F, (this.duration - 0.3F) / 0.3F) * Settings.scale;
@@ -89,8 +93,8 @@ public class ThrowVegetableEffect extends AbstractGameEffect {
         float height = img.getHeight();
 
         sb.setBlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
-        for(int i = 5; i < this.previousPos.size(); ++i) {
-            this.color.a = 0.2f * i;
+        for(int i = 0; i < this.previousPos.size(); i++) {
+            this.color.a = 0.1f * i;
             sb.setColor(this.color);
             sb.draw(img, this.previousPos.get(i).x, this.previousPos.get(i).y, width / 2.0F, height / 2.0F, width, height, this.scale * i / 10f, this.scale * i / 10f, this.rotation, 0, 0, img.getWidth(), img.getHeight(), false, false);
         }

--- a/src/main/java/spireMapOverhaul/zones/grass/vegetables/AbstractVegetableData.java
+++ b/src/main/java/spireMapOverhaul/zones/grass/vegetables/AbstractVegetableData.java
@@ -22,6 +22,7 @@ public class AbstractVegetableData {
     public int maxUpgradeLevel = 5;
     public float bounce = 200f;
     public float duration = 0.6f;
+    public float rotation = 600f;
 
     public AbstractVegetableData(Constructor<? extends AbstractVegetable> constructor, String id, String imagePath) {
         this(constructor, id, imagePath, CardCrawlGame.languagePack.getOrbString(id));


### PR DESCRIPTION
- Adjustments for vegetable throwing VFX
- Fix wrong name being used in relic rewards when the Grass zone replaces them