### PR TITLE
(Ambushed) Reduced zone size, updated UI strings, added Courier support

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/ambushed/AmbushedZone.java
+++ b/src/main/java/spireMapOverhaul/zones/ambushed/AmbushedZone.java
@@ -58,7 +58,7 @@ public class AmbushedZone extends AbstractZone implements CombatModifyingZone, E
     public AmbushedZone() {
         super(ID, Icons.MONSTER, Icons.SHOP);
         this.width = 3;
-        this.height = 4;
+        this.height = 3;
         initCardDrawCardIDs();
     }
 
@@ -234,6 +234,43 @@ public class AmbushedZone extends AbstractZone implements CombatModifyingZone, E
         boolean isCardColored = card.color != AbstractCard.CardColor.COLORLESS;
         return card != null && card.rarity == rarity && card.type == type && isCardColored == isColored;
     }
+
+    @Override
+    public AbstractCard getReplacementShopCardForCourier(AbstractCard purchasedCard) {
+        boolean isColored = purchasedCard.color != AbstractCard.CardColor.COLORLESS;
+        AbstractCard replacementCard = getCardForCourier(purchasedCard.type, isColored);
+
+        // Handle the case where no replacement card is found
+        if (replacementCard == null) {
+            // You can decide how to handle this - return null, a default card, etc.
+            return null; // or some default behavior
+        }
+
+        return replacementCard;
+    }
+
+    private AbstractCard getCardForCourier(AbstractCard.CardType type, boolean isColored) {
+        HashSet<String> selectedCardIDs = new HashSet<>(); // To avoid selecting the same card
+
+        // Filter cards by type and whether it's colored or colorless
+        List<String> filteredCardIDs = cardDrawCardIDs.stream()
+                .filter(id -> isCardSuitableForCourier(id, type, isColored))
+                .collect(Collectors.toList());
+
+        if (!filteredCardIDs.isEmpty()) {
+            String selectedCardID = filteredCardIDs.get(AbstractDungeon.cardRng.random(filteredCardIDs.size() - 1));
+            return CardLibrary.getCard(selectedCardID).makeCopy();
+        }
+
+        return null;
+    }
+
+    private boolean isCardSuitableForCourier(String cardID, AbstractCard.CardType type, boolean isColored) {
+        AbstractCard card = CardLibrary.getCard(cardID);
+        boolean isCardColored = card.color != AbstractCard.CardColor.COLORLESS;
+        return card != null && card.type == type && isCardColored == isColored;
+    }
+
 
     @Override
     public void postCreateShopPotions(ShopScreen screen, ArrayList<StorePotion> potions) {

--- a/src/main/java/spireMapOverhaul/zones/ambushed/AmbushedZone.java
+++ b/src/main/java/spireMapOverhaul/zones/ambushed/AmbushedZone.java
@@ -240,17 +240,14 @@ public class AmbushedZone extends AbstractZone implements CombatModifyingZone, E
         boolean isColored = purchasedCard.color != AbstractCard.CardColor.COLORLESS;
         AbstractCard replacementCard = getCardForCourier(purchasedCard.type, isColored);
 
-        // Handle the case where no replacement card is found
         if (replacementCard == null) {
-            // You can decide how to handle this - return null, a default card, etc.
-            return null; // or some default behavior
+            return null;
         }
 
         return replacementCard;
     }
 
     private AbstractCard getCardForCourier(AbstractCard.CardType type, boolean isColored) {
-        HashSet<String> selectedCardIDs = new HashSet<>(); // To avoid selecting the same card
 
         // Filter cards by type and whether it's colored or colorless
         List<String> filteredCardIDs = cardDrawCardIDs.stream()

--- a/src/main/resources/anniv6Resources/localization/eng/Ambushed/UIstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/Ambushed/UIstrings.json
@@ -2,7 +2,7 @@
   "${ModID}:Ambushed": {
     "TEXT": [
       "Ambushed!",
-      "You've been ambushed! Start each combat #ySurrounded by two enemies in #rhighly #rdifficult fights inspired by base game encounters. NL NL Rewards include immediate card draw options.",
+      "You've been ambushed! Start each combat #ySurrounded by two enemies in #rhighly #rdifficult fights inspired by base game encounters. NL NL Rewards include immediate card draw options from any base game color.",
       "Cany0udance"
     ]
   }


### PR DESCRIPTION
The potential for 4 straight floors of card draw cards could feel bad for players in Act 1 because only the utility of the deck improves when they need block/damage, so reducing height by 25% should help with that frustration.

Also I simply don't have enough combats for the zone, 4 nodes made it very likely for repeats to occur