### PR TITLE
Fix Mirror Move crash

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/mirror/cards/MirrorMove.java
+++ b/src/main/java/spireMapOverhaul/zones/mirror/cards/MirrorMove.java
@@ -309,7 +309,7 @@ public class MirrorMove extends AbstractSMOCard {
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        if (moveData.isEmpty()) {
+        if (moveData == null || moveData.isEmpty()) {
             return;
         }
         if (gainEnergy) {

--- a/src/main/java/spireMapOverhaul/zones/mirror/cards/MirrorMove.java
+++ b/src/main/java/spireMapOverhaul/zones/mirror/cards/MirrorMove.java
@@ -114,7 +114,7 @@ public class MirrorMove extends AbstractSMOCard {
 
     @Override
     public void applyPowers() {
-        if (moveData != MirrorZone.chosenMoveData) {
+        if (moveData == null && MirrorZone.chosenMoveData != null) {
             setMoveData(MirrorZone.chosenMoveData, true);
         }
         super.applyPowers();


### PR DESCRIPTION
Turns out the crash happens if `moveData` is null. The first commit fixes this.

But why `moveData` was null in the first place? Because Mirror Move had some "transformation" mechanic to it. I wanted all instances of Mirror Move to have the same move data, so it changed it in `applyPowers`. Though it never changes while in Exhaust pile, creating inconsistencies like:
- After you Exhume a Mirror Move, it changes its description.
- When Mirror Move is exhausted due to Ethereal, it **sometimes** changes its data to null. (This is probably what happened in the crash report)

I'm removing this confusing behavior in the second commit. Now, once the `moveData` of Mirror Move is set, it never changes.
