### PR TITLE
Update Jurors with Verdict tooltip in event and add utility for creating these tooltips. Rebalance Eclectic.

### DIFF
--- a/src/main/java/spireMapOverhaul/util/EventTooltipCreator.java
+++ b/src/main/java/spireMapOverhaul/util/EventTooltipCreator.java
@@ -1,0 +1,47 @@
+package spireMapOverhaul.util;
+
+import com.evacipated.cardcrawl.mod.stslib.Keyword;
+import com.megacrit.cardcrawl.helpers.PowerTip;
+import com.megacrit.cardcrawl.relics.Circlet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import spireMapOverhaul.SpireAnniversary6Mod;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class EventTooltipCreator {
+  private static final Logger LOG = LogManager.getLogger(EventTooltipCreator.class);
+
+  /**
+   * Create a Circlet with custom tooltips. This can be passed into the AbstractRelic parameter of {@link basemod.abstracts.events.phases.TextPhase.OptionInfo TextPhase.OptionInfo}
+   * to allow for rendering additional tooltips when the option is hovered in a {@link basemod.abstracts.events.PhasedEvent PhasedEvent}.
+   *
+   * @see basemod.abstracts.events.phases.TextPhase.OptionInfo
+   * @see basemod.abstracts.events.PhasedEvent
+   * @param keywords The list of keywords that should be applied to the relic.
+   * @return A circlet instance with its keywords overridden to match those provided
+   */
+  public static Circlet createRelicForTootlips(String...keywords) {
+    if(keywords == null || keywords.length == 0) {
+      return null;
+    }
+
+    Circlet circlet = new Circlet();
+    circlet.tips.clear();
+    circlet.tips.addAll(Arrays.stream(keywords)
+        .filter(Objects::nonNull)
+        .map(key -> {
+          Keyword keyword = SpireAnniversary6Mod.keywords.get(key);
+          if(keyword == null) {
+            LOG.info("Could not locate keyword with ID {} for event tooltip. Make sure keyword has ID key defined in your Keywordstrings.json.", key);
+          }
+          return keyword;
+        })
+        .filter(Objects::nonNull)
+        .map(keyword -> new PowerTip(keyword.PROPER_NAME, keyword.DESCRIPTION))
+        .collect(Collectors.toList()));
+    return circlet.tips.size() == 0 ? null : circlet;
+  }
+}

--- a/src/main/java/spireMapOverhaul/zones/divinitiesgaze/divinities/DivineBeing.java
+++ b/src/main/java/spireMapOverhaul/zones/divinitiesgaze/divinities/DivineBeing.java
@@ -8,17 +8,23 @@ import java.util.function.Supplier;
 public interface DivineBeing {
   DivinityStrings getDivinityStrings();
   Consumer<Integer> doEventButtonAction();
+
   default String getCombatPhaseKey() {
     return "";
   }
+
   default Supplier<Boolean> isEventOptionEnabled() {
     return () -> true;
   }
+
   default Consumer<AbstractRoom> getCombatRewards() { return room -> {};}
+
   default boolean doUpdate() {
     return true;
   }
+
   default void doEnterCombat() {}
+
   default boolean hasUpdateLogic() {
     return false;
   }
@@ -37,5 +43,13 @@ public interface DivineBeing {
 
   default String getEventButtonUnavailableText() {
     return getDivinityStrings().getEventButtonUnavailableText();
+  }
+
+  default String[] getKeywordsForCardChoice(){
+    return new String[]{};
+  }
+
+  default String[] getKeywordsForCustomChoice(){
+    return new String[]{};
   }
 }

--- a/src/main/java/spireMapOverhaul/zones/divinitiesgaze/divinities/impl/Eclectic.java
+++ b/src/main/java/spireMapOverhaul/zones/divinitiesgaze/divinities/impl/Eclectic.java
@@ -26,7 +26,7 @@ public class Eclectic extends BaseDivineBeing {
     return x -> {
       CardGroup group = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
       Set<UUID> cardUUIDs = new HashSet<>();
-      while (group.size() < 20) {
+      while (group.size() < 10) {
         AbstractCard card = AbstractDungeon.getCard(AbstractDungeon.rollRarity());
         if(!cardUUIDs.contains(card.uuid)) {
           cardUUIDs.add(card.uuid);

--- a/src/main/java/spireMapOverhaul/zones/divinitiesgaze/divinities/impl/Jurors.java
+++ b/src/main/java/spireMapOverhaul/zones/divinitiesgaze/divinities/impl/Jurors.java
@@ -75,4 +75,14 @@ public class Jurors extends BaseDivineBeing {
       }
     });
   }
+
+  @Override
+  public String[] getKeywordsForCardChoice() {
+    return new String[]{VerdictPower.KEYWORD};
+  }
+
+  @Override
+  public String[] getKeywordsForCustomChoice() {
+    return new String[]{VerdictPower.KEYWORD};
+  }
 }

--- a/src/main/java/spireMapOverhaul/zones/divinitiesgaze/events/DivineVisitor.java
+++ b/src/main/java/spireMapOverhaul/zones/divinitiesgaze/events/DivineVisitor.java
@@ -14,6 +14,7 @@ import com.megacrit.cardcrawl.localization.EventStrings;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect;
 import spireMapOverhaul.SpireAnniversary6Mod;
+import spireMapOverhaul.util.EventTooltipCreator;
 import spireMapOverhaul.zones.divinitiesgaze.divinities.DivineBeing;
 import spireMapOverhaul.zones.divinitiesgaze.divinities.DivineBeingManager;
 
@@ -46,11 +47,13 @@ public class DivineVisitor extends PhasedEvent {
     AbstractCard boonCard = CardLibrary.getCard(this.divinity.getDivinityStrings().getBoonCardId());
     String combatPhaseKey = this.divinity.getCombatPhaseKey();
     registerPhase(Phase.APPEARANCE, new TextPhase(this.divinity.getDivinityStrings().getEventText())
-        .addOption(new TextPhase.OptionInfo(String.format(OPTIONS[1], FontHelper.colorString(boonCard.name, "g")), boonCard).setOptionResult(i -> {
+        .addOption(new TextPhase.OptionInfo(String.format(OPTIONS[1], FontHelper.colorString(boonCard.name, "g")),
+            boonCard, EventTooltipCreator.createRelicForTootlips(this.divinity.getKeywordsForCardChoice())).setOptionResult(i -> {
           AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(boonCard, (float) Settings.WIDTH / 2.0F, (float)Settings.HEIGHT / 2.0F));
           transitionKey(Phase.ACCEPT);
         }))
-        .addOption(new TextPhase.OptionInfo(this.divinity.isEventOptionEnabled().get() ? this.divinity.getEventButtonText() : this.divinity.getEventButtonUnavailableText())
+        .addOption(new TextPhase.OptionInfo(this.divinity.isEventOptionEnabled().get() ? this.divinity.getEventButtonText() : this.divinity.getEventButtonUnavailableText(),
+            EventTooltipCreator.createRelicForTootlips(this.divinity.getKeywordsForCustomChoice()))
             .setOptionResult(this.divinity.doEventButtonAction().andThen(i -> {
               if(!DivineVisitor.this.divinity.hasUpdateLogic()) {
                 transitionKey((!combatPhaseKey.isEmpty()) ? Phase.COMBAT : Phase.ACCEPT);

--- a/src/main/java/spireMapOverhaul/zones/divinitiesgaze/powers/VerdictPower.java
+++ b/src/main/java/spireMapOverhaul/zones/divinitiesgaze/powers/VerdictPower.java
@@ -20,6 +20,7 @@ public class VerdictPower extends AbstractSMOPower implements HealthBarRenderPow
   private static final PowerStrings powerStrings = CardCrawlGame.languagePack.getPowerStrings(POWER_ID);
   public static final String NAME = powerStrings.NAME;
   public static final String[] DESCRIPTIONS = powerStrings.DESCRIPTIONS;
+  public static final String KEYWORD = SpireAnniversary6Mod.makeID("Verdict");
 
   public VerdictPower(AbstractCreature owner, int amount) {
     super(POWER_ID, NAME, DivinitiesGazeZone.ID, PowerType.DEBUFF, false, owner, amount);

--- a/src/main/java/spireMapOverhaul/zones/manasurge/events/ManaCycloneEvent.java
+++ b/src/main/java/spireMapOverhaul/zones/manasurge/events/ManaCycloneEvent.java
@@ -7,13 +7,13 @@ import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-import com.megacrit.cardcrawl.helpers.PowerTip;
 import com.megacrit.cardcrawl.helpers.RelicLibrary;
 import com.megacrit.cardcrawl.localization.EventStrings;
 import com.megacrit.cardcrawl.relics.*;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.vfx.cardManip.ShowCardBrieflyEffect;
 import spireMapOverhaul.SpireAnniversary6Mod;
+import spireMapOverhaul.util.EventTooltipCreator;
 import spireMapOverhaul.zones.manasurge.ManaSurgeZone;
 import spireMapOverhaul.zones.manasurge.ui.campfire.EnchantOption;
 import spireMapOverhaul.zones.manasurge.vfx.EnchantBlightEffect;
@@ -55,17 +55,8 @@ public class ManaCycloneEvent extends PhasedEvent {
         float cardWidth = AbstractCard.IMG_WIDTH;
         float horizontalOffset = cardWidth * 0.75F;
 
-        AbstractRelic rEnchantBlight = new Circlet();
-        rEnchantBlight.tips.clear();
-        rEnchantBlight.tips.add(new PowerTip(ManaSurgeZone.getKeywordProper(ENCHANT_ID), ManaSurgeZone.getKeywordDescription(ENCHANT_ID)));
-        rEnchantBlight.tips.add(new PowerTip(ManaSurgeZone.getKeywordProper(BLIGHTED_ID), ManaSurgeZone.getKeywordDescription(BLIGHTED_ID)));
-
-        AbstractRelic rBlight = new Circlet();
-        rBlight.tips.clear();
-        rBlight.tips.add(new PowerTip(ManaSurgeZone.getKeywordProper(BLIGHTED_ID), ManaSurgeZone.getKeywordDescription(BLIGHTED_ID)));
-
         registerPhase("Start", new TextPhase(DESCRIPTIONS[0])
-                .addOption(new TextPhase.OptionInfo(OPTIONS[0],rEnchantBlight)
+                .addOption(new TextPhase.OptionInfo(OPTIONS[0], EventTooltipCreator.createRelicForTootlips(ENCHANT_ID, BLIGHTED_ID))
                         .cardSelectOption("Reached Inside",
                                 ()->{
                                     CardGroup filteredCards = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
@@ -112,7 +103,7 @@ public class ManaCycloneEvent extends PhasedEvent {
                                 }
                         )
                 )
-                .addOption(OPTIONS[1],rBlight,(i) -> {
+                .addOption(OPTIONS[1], EventTooltipCreator.createRelicForTootlips(BLIGHTED_ID), (i) -> {
                     CardGroup filteredCards = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
                     AbstractDungeon.player.masterDeck.group.stream()
                             .filter(card -> !ManaSurgeZone.hasManaSurgeModifier(card) &&

--- a/src/main/resources/anniv6Resources/localization/eng/DivinitiesGaze/Keywordstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/DivinitiesGaze/Keywordstrings.json
@@ -1,5 +1,6 @@
 [
   {
+    "ID": "${ModID}:Verdict",
     "PROPER_NAME": "Verdict",
     "NAMES": ["verdict"],
     "DESCRIPTION": "A creature with #yVerdict dies at the start of its turn if its current HP is less than its #yVerdict. Otherwise, it gains #b5 #yVerdict."

--- a/src/main/resources/anniv6Resources/localization/eng/DivinitiesGaze/UIstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/DivinitiesGaze/UIstrings.json
@@ -17,7 +17,7 @@
       "NAME": "Ken",
       "TITLE": "The Eclectic",
       "EVENT_TEXT": "Sounds of pages turning and the stale smell of old tomes surrounds you. You make eye contact with them, among their #yEclectic collection. NL NL In their eyes, you see every thought that has ever #rbeen, and all those that will #gbe. NL NL They speak: \"Another... You, too... #y@learn@ as we have...\"",
-      "EVENT_BUTTON_TEXT": "[Learn] #gChoose #g1 #gof #g20 #gupgraded #gcards #gto #gadd #gto #gyour #gdeck.",
+      "EVENT_BUTTON_TEXT": "[Learn] #gChoose #g1 #gof #g10 #gupgraded #gcards #gto #gadd #gto #gyour #gdeck.",
       "EVENT_ACCEPT_TEXT": "~Quiet...~ NL NL Like a library at night, no sound can be heard as they leave. You have #glearned... but what you have seen will not soon be forgotten.",
       "EVENT_REJECT_TEXT": "~Quiet...~ NL NL Like a library at night, no sound can be heard as they leave. What could they have taught you, had you listened? NL NL Have you made the right choice?",
       "SELECT_TEXT": "Choose a card to add to your deck."


### PR DESCRIPTION
ADD: Utility for creating Circlets to display tooltips on PhasedEvent options
ADD: Tooltip for Verdict power to Jurors' options in Divine Visitor event
CHANGE: Mana Storm event now uses Circlet utility
BALANCE: Eclectic event cards to choose from: 20 -> 10