### PR TITLE
Heavenly Clouds zone: change Flighty to remove itself after being triggered and to use a tooltip instead of adding to the card description

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/heavenlyClouds/FlightMod.java
+++ b/src/main/java/spireMapOverhaul/zones/heavenlyClouds/FlightMod.java
@@ -1,12 +1,21 @@
 package spireMapOverhaul.zones.heavenlyClouds;
 
+import basemod.BaseMod;
 import basemod.abstracts.AbstractCardModifier;
+import basemod.helpers.CardModifierManager;
+import basemod.helpers.TooltipInfo;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.DrawCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
-import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import spireMapOverhaul.SpireAnniversary6Mod;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static spireMapOverhaul.SpireAnniversary6Mod.makeID;
+import static spireMapOverhaul.util.Wiz.atb;
 
 public class FlightMod extends AbstractCardModifier {
 
@@ -26,7 +35,14 @@ public class FlightMod extends AbstractCardModifier {
         if (!used) {
             used = true;
             card.flash();
-            AbstractDungeon.actionManager.addToBottom(new DrawCardAction(1));
+            atb(new DrawCardAction(1));
+            atb(new AbstractGameAction() {
+                @Override
+                public void update() {
+                    CardModifierManager.removeModifiersById(card, ID, false);
+                    isDone = true;
+                }
+            });
         }
     }
 
@@ -37,11 +53,13 @@ public class FlightMod extends AbstractCardModifier {
 
     @Override
     public String modifyName(String cardName, AbstractCard card) {
-        return TEXT[1] + cardName;
+        return TEXT[0] + cardName;
     }
 
     @Override
-    public String modifyDescription(String rawDescription, AbstractCard card) {
-        return rawDescription + TEXT[0];
+    public List<TooltipInfo> additionalTooltips(AbstractCard card) {
+        ArrayList<TooltipInfo> tooltips = new ArrayList<>();
+        tooltips.add(new TooltipInfo(BaseMod.getKeywordTitle(makeID("flighty")), BaseMod.getKeywordDescription(makeID("flighty"))));
+        return tooltips;
     }
 }

--- a/src/main/resources/anniv6Resources/localization/eng/HeavenlyClouds/Keywordstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/HeavenlyClouds/Keywordstrings.json
@@ -1,0 +1,9 @@
+[
+  {
+    "PROPER_NAME": "Flighty",
+    "NAMES": [
+      "flighty"
+    ],
+    "DESCRIPTION": "When drawn, draw #b1 card and remove #yFlighty."
+  }
+]

--- a/src/main/resources/anniv6Resources/localization/eng/HeavenlyClouds/UIstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/HeavenlyClouds/UIstrings.json
@@ -8,7 +8,6 @@
   },
   "${ModID}:FlightMod": {
     "TEXT": [
-      " NL The first time this card is drawn each combat, draw 1 card.",
       "Flighty "
     ]
   },


### PR DESCRIPTION
This is the same way Electric (from the Storm zone) does it, and I think the UX is better. You don't get cards with super tiny text, and it's clear when the mod has been triggered already this combat.