### PR TITLE
Grass zone: fix spawning duplicate relics

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/grass/GrassZone.java
+++ b/src/main/java/spireMapOverhaul/zones/grass/GrassZone.java
@@ -124,6 +124,9 @@ public class GrassZone extends AbstractZone implements CombatModifyingZone, Rend
                             && AbstractDungeon.relicRng.randomBoolean(getRelicChance())) {
                         rewardItem.relic = newRelic.makeCopy();
                         rewardItem.text = newRelic.name;
+                        if (relicPool != null) {
+                            relicPool.remove(relicID);
+                        }
                         // Add the old relic back in to the pool so that it can spawn again
                         Wiz.addRelicToPool(origRelic);
                         break;
@@ -149,6 +152,9 @@ public class GrassZone extends AbstractZone implements CombatModifyingZone, Rend
                             && (relicPool == null || relicPool.contains(relicID))
                             && AbstractDungeon.relicRng.randomBoolean(getRelicChance())) {
                         first.relic = newRelic.makeCopy();
+                        if (relicPool != null) {
+                            relicPool.remove(relicID);
+                        }
                         // Add the old relic back in to the pool so that it can spawn again
                         Wiz.addRelicToPool(origRelic);
                         break;


### PR DESCRIPTION
This fixes both the issue that was reported in the Workshop thread and other issues related to the relics still being in the relic pool.