### PR TITLE
Divinities' Gaze: Verdict and Inevitability Adjustments

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/divinitiesgaze/cards/Inevitability.java
+++ b/src/main/java/spireMapOverhaul/zones/divinitiesgaze/cards/Inevitability.java
@@ -16,12 +16,12 @@ import spireMapOverhaul.zones.divinitiesgaze.DivinitiesGazeZone;
 public class Inevitability extends AbstractSMOCard {
   public static String ID = SpireAnniversary6Mod.makeID("Inevitability");
   private static boolean canTalk = true;
+  private static final int STAT_INCREMENT = 1;
 
   public Inevitability() {
     super(ID, DivinitiesGazeZone.ID, -2, CardType.SKILL, CardRarity.SPECIAL, CardTarget.ALL, CardColor.COLORLESS);
     this.magicNumber = this.baseMagicNumber = 5;
-    this.block = this.baseBlock = 3;
-    this.secondMagic = this.baseSecondMagic = 1;
+    this.secondMagic = this.baseSecondMagic = 3;
     this.isMultiDamage = true;
     this.selfRetain = true;
   }
@@ -29,7 +29,7 @@ public class Inevitability extends AbstractSMOCard {
   @Override
   public void upp() {
     upgradeMagicNumber(2);
-    upgradeBlock(1);
+    upgradeSecondMagic(2);
   }
 
   @Override
@@ -54,13 +54,13 @@ public class Inevitability extends AbstractSMOCard {
     }
     Wiz.atb(new DamageAllEnemiesAction(AbstractDungeon.player, DamageInfo.createDamageMatrix(this.magicNumber, true),
         DamageInfo.DamageType.THORNS, AbstractGameAction.AttackEffect.NONE));
-    Wiz.atb(new GainBlockAction(AbstractDungeon.player, this.block));
+    Wiz.atb(new GainBlockAction(AbstractDungeon.player, this.secondMagic));
     Wiz.atb(new AbstractGameAction() {
       @Override
       public void update() {
         this.isDone = true;
-        Inevitability.this.baseMagicNumber += Inevitability.this.secondMagic;
-        Inevitability.this.baseBlock += Inevitability.this.secondMagic;
+        Inevitability.this.baseMagicNumber += STAT_INCREMENT;
+        Inevitability.this.baseBlock += STAT_INCREMENT;
       }
     });
   }

--- a/src/main/java/spireMapOverhaul/zones/divinitiesgaze/powers/VerdictPower.java
+++ b/src/main/java/spireMapOverhaul/zones/divinitiesgaze/powers/VerdictPower.java
@@ -39,7 +39,7 @@ public class VerdictPower extends AbstractSMOPower implements HealthBarRenderPow
 
   @Override
   public int getHealthBarAmount() {
-    return this.amount;
+    return this.amount - 1;
   }
 
   @Override

--- a/src/main/resources/anniv6Resources/localization/eng/DivinitiesGaze/Cardstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/DivinitiesGaze/Cardstrings.json
@@ -24,7 +24,7 @@
   },
   "${ModID}:Inevitability": {
     "NAME": "Inevitability",
-    "DESCRIPTION": "Unplayable. Retain. At the end of your turn, deal !M! damage to ALL enemies and gain !B! Block. NL Increase these amounts by !${ModID}:secondMagic}! this combat.",
+    "DESCRIPTION": "Unplayable. Retain. At the end of your turn, deal !M! damage to ALL enemies and gain !${ModID}:m2! Block. NL Increase these amounts by 1 this combat.",
     "EXTENDED_DESCRIPTION": [
       "This is The End.",
       "Begone!",

--- a/src/main/resources/anniv6Resources/localization/zhs/DivinitiesGaze/Cardstrings.json
+++ b/src/main/resources/anniv6Resources/localization/zhs/DivinitiesGaze/Cardstrings.json
@@ -24,7 +24,7 @@
   },
   "${ModID}:Inevitability": {
     "NAME": "逃无可逃",
-    "DESCRIPTION": "不可打出 NL 保留 NL 在你回合结束时，对所有敌人造成 !D! 点伤害并获得 !B! 点格挡 NL 每过一回合，数值增加 !M! ",
+    "DESCRIPTION": "不可打出 NL 保留 NL 在你回合结束时，对所有敌人造成 !M! 点伤害并获得 !${ModID}:m2! 点格挡 NL 每过一回合，数值增加 1 ",
     "EXTENDED_DESCRIPTION": [
       "这便是终途",
       "让开！",


### PR DESCRIPTION
CHANGE: Moved Inevitability block to magic number to not give the implication that it scales.
BALANCE: Increased base block on Inevitability+ by 1.
VISUAL: Verdict's Health Bar Render now shows stacks less 1 instead of stacks. This means that a fully-shaded bar now always indicates that the enemy will die at the start of its next turn.