### PR TITLE
Broken Space zone: fix being able to get the benefit from Broken Maw Bank multiple times

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/brokenspace/relics/BrokenMawBank.java
+++ b/src/main/java/spireMapOverhaul/zones/brokenspace/relics/BrokenMawBank.java
@@ -1,8 +1,13 @@
 package spireMapOverhaul.zones.brokenspace.relics;
 
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch2;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePrefixPatch;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.relics.MawBank;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.rooms.ShopRoom;
+import com.megacrit.cardcrawl.saveAndContinue.SaveFile;
+import spireMapOverhaul.SpireAnniversary6Mod;
 
 import static spireMapOverhaul.util.Wiz.adp;
 
@@ -10,33 +15,15 @@ public class BrokenMawBank extends BrokenRelic {
     public static final String ID = "BrokenMawBank";
     public static final int AMOUNT = 400;
 
-
-    private boolean used = false;
     private boolean active = false;
 
     public BrokenMawBank() {
         super(ID, RelicTier.SPECIAL, LandingSound.CLINK, MawBank.ID);
-
-        if (counter == -2) {
-            grayscale = true;
-            used = true;
-        }
     }
-
 
     @Override
     public void onEnterRoom(AbstractRoom room) {
-
-        if (active) {
-            active = false;
-            this.flash();
-            adp().loseGold(AMOUNT);
-            used = true;
-            grayscale = true;
-            counter = -2;
-        }
-
-        if (room instanceof ShopRoom && !used) {
+        if (room instanceof ShopRoom && !usedUp) {
             this.flash();
             adp().gainGold(AMOUNT);
             active = true;
@@ -44,9 +31,31 @@ public class BrokenMawBank extends BrokenRelic {
         super.onEnterRoom(room);
     }
 
+    @Override
+    public void setCounter(int setCounter) {
+        this.counter = setCounter;
+        if (setCounter == -2) {
+            this.usedUp();
+        }
+    }
 
     @Override
     public String getUpdatedDescription() {
         return DESCRIPTIONS[0] + AMOUNT + DESCRIPTIONS[1] + AMOUNT + DESCRIPTIONS[2];
+    }
+
+    @SpirePatch2(clz = AbstractDungeon.class, method = "nextRoomTransition", paramtypez = { SaveFile.class })
+    public static class BrokenMawBankPatch {
+        @SpirePrefixPatch
+        public static void MarkRelicAsUsed(AbstractDungeon __instance, SaveFile saveFile) {
+            BrokenMawBank brokenMawBank = (BrokenMawBank)adp().getRelic(SpireAnniversary6Mod.makeID(BrokenMawBank.ID));
+            if (brokenMawBank != null && brokenMawBank.active) {
+                brokenMawBank.active = false;
+                brokenMawBank.flash();
+                adp().loseGold(AMOUNT);
+                brokenMawBank.usedUp();
+                brokenMawBank.counter = -2;
+            }
+        }
     }
 }


### PR DESCRIPTION
This can happen if you save and reload on the floor after the shop where it triggers. Plus there were some other save and load issues. Also changed it to use the standard system for used up relics.