### PR TITLE
Consolidated bug fixes

### DIFF
--- a/src/main/java/spireMapOverhaul/util/Wiz.java
+++ b/src/main/java/spireMapOverhaul/util/Wiz.java
@@ -29,6 +29,7 @@ import spireMapOverhaul.actions.TimedVFXAction;
 import spireMapOverhaul.patches.ZonePatches;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -108,6 +109,12 @@ public class Wiz {
             default:
                 return null;
         }
+    }
+
+    public static boolean isNormalRelicTier(AbstractRelic.RelicTier tier) {
+        // To account for other mods trying to introduce new relic tiers, we check this by specifically looking for the five normal tiers that have pools (i.e. everything except special)
+        List<AbstractRelic.RelicTier> knownTiers = Arrays.asList(AbstractRelic.RelicTier.COMMON, AbstractRelic.RelicTier.UNCOMMON, AbstractRelic.RelicTier.RARE, AbstractRelic.RelicTier.BOSS, AbstractRelic.RelicTier.SHOP);
+        return knownTiers.contains(tier);
     }
 
     public static int asc() { return AbstractDungeon.ascensionLevel; }

--- a/src/main/java/spireMapOverhaul/zones/brokenspace/BrokenSpaceZone.java
+++ b/src/main/java/spireMapOverhaul/zones/brokenspace/BrokenSpaceZone.java
@@ -171,7 +171,7 @@ public class BrokenSpaceZone extends AbstractZone implements RewardModifyingZone
 
     @Override
     public void modifyReward(RewardItem rewardItem) {
-        if (rewardItem.type == RewardItem.RewardType.RELIC) {
+        if (rewardItem.type == RewardItem.RewardType.RELIC && Wiz.isNormalRelicTier(rewardItem.relic.tier)) {
             AbstractRelic origRelic = rewardItem.relic;
             AbstractRelic newRelic = getValidBrokenRelic();
 

--- a/src/main/java/spireMapOverhaul/zones/brokenspace/cardmods/UnreadableCardMod.java
+++ b/src/main/java/spireMapOverhaul/zones/brokenspace/cardmods/UnreadableCardMod.java
@@ -35,11 +35,6 @@ public class UnreadableCardMod extends AbstractCardModifier {
         return ID;
     }
 
-    @Override
-    public boolean removeAtEndOfTurn(AbstractCard card) {
-        return true;
-    }
-
     public String randomText(int length) {
         String chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*()_+{}[];':\",./<>?\\|`~-=_+??????????????";
         StringBuilder builder = new StringBuilder();

--- a/src/main/java/spireMapOverhaul/zones/candyland/CandyLand.java
+++ b/src/main/java/spireMapOverhaul/zones/candyland/CandyLand.java
@@ -16,6 +16,7 @@ import com.megacrit.cardcrawl.ui.campfire.RestOption;
 import com.megacrit.cardcrawl.ui.campfire.SmithOption;
 import spireMapOverhaul.abstracts.AbstractZone;
 import spireMapOverhaul.rewards.HealReward;
+import spireMapOverhaul.util.Wiz;
 import spireMapOverhaul.zoneInterfaces.CampfireModifyingZone;
 import spireMapOverhaul.zoneInterfaces.RewardModifyingZone;
 import spireMapOverhaul.zoneInterfaces.ShopModifyingZone;
@@ -68,7 +69,7 @@ public class CandyLand extends AbstractZone implements RewardModifyingZone, Camp
 
     @Override
     public void modifyReward(RewardItem rewardItem) {
-        if(rewardItem.type == RewardItem.RewardType.RELIC && !(rewardItem.relic instanceof Mango || rewardItem.relic instanceof Pear || rewardItem.relic instanceof Strawberry || rewardItem.relic instanceof Waffle)){
+        if(rewardItem.type == RewardItem.RewardType.RELIC && !(rewardItem.relic instanceof Mango || rewardItem.relic instanceof Pear || rewardItem.relic instanceof Strawberry || rewardItem.relic instanceof Waffle) && Wiz.isNormalRelicTier(rewardItem.relic.tier)){
             switch(rewardItem.relic.tier){
                 case RARE:
                     rewardItem.relic = new Mango();

--- a/src/main/java/spireMapOverhaul/zones/frostlands/relics/Contraption.java
+++ b/src/main/java/spireMapOverhaul/zones/frostlands/relics/Contraption.java
@@ -1,6 +1,8 @@
 package spireMapOverhaul.zones.frostlands.relics;
 
 import com.evacipated.cardcrawl.mod.stslib.relics.OnPlayerDeathRelic;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.GameActionManager;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.utility.WaitAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
@@ -75,13 +77,25 @@ public class Contraption extends AbstractSMORelic implements OnPlayerDeathRelic 
 
             AbstractDungeon.actionManager.currentAction.isDone = true;
             AbstractDungeon.getCurrRoom().smoked = true;
-            this.addToBot(new VFXAction(new SmokeBombEffect(target.hb.cX, target.hb.cY)));
-            Wiz.att(new WaitAction(.1f));
+            AbstractDungeon.actionManager.actions.clear();
+            AbstractDungeon.actionManager.monsterQueue.clear();
+            float escapeDuration = 2.5f;
+            Wiz.atb(new WaitAction(.1f));
+            Wiz.atb(new VFXAction(new SmokeBombEffect(target.hb.cX, target.hb.cY)));
+            Wiz.atb(new AbstractGameAction() {
+                {
+                    this.duration = escapeDuration;
+                }
+                @Override
+                public void update() {
+                    this.tickDuration();
+                }
+            });
             AbstractDungeon.player.hideHealthBar();
             AbstractDungeon.player.isEscaping = true;
             AbstractDungeon.player.flipHorizontal = !AbstractDungeon.player.flipHorizontal;
             AbstractDungeon.overlayMenu.endTurnButton.disable();
-            AbstractDungeon.player.escapeTimer = 2.5F;
+            AbstractDungeon.player.escapeTimer = escapeDuration;
         }
         if(AbstractDungeon.getCurrRoom().event instanceof SnowmanMafiaEvent)
             ((SnowmanMafiaEvent) AbstractDungeon.getCurrRoom().event).usedContraption();

--- a/src/main/java/spireMapOverhaul/zones/grass/GrassZone.java
+++ b/src/main/java/spireMapOverhaul/zones/grass/GrassZone.java
@@ -110,7 +110,7 @@ public class GrassZone extends AbstractZone implements CombatModifyingZone, Rend
 
     @Override
     public void modifyReward(RewardItem rewardItem) {
-        if (rewardItem.type == RewardItem.RewardType.RELIC) {
+        if (rewardItem.type == RewardItem.RewardType.RELIC && Wiz.isNormalRelicTier(rewardItem.relic.tier)) {
             AbstractRelic origRelic = rewardItem.relic;
             for (String relicID : GRASS_RELICS) {
                 AbstractRelic newRelic = RelicLibrary.getRelic(relicID);

--- a/src/main/java/spireMapOverhaul/zones/gremlinTown/GremlinTown.java
+++ b/src/main/java/spireMapOverhaul/zones/gremlinTown/GremlinTown.java
@@ -237,8 +237,8 @@ public class GremlinTown extends AbstractZone
         // These start in their combat positions instead of spawning off the screen and being animated
         encounters.add(new ZoneEncounter(SURPRISE, 2, () -> new MonsterGroup(
                 new AbstractMonster[]{
-                    new GremlinRiderRed((Settings.WIDTH * -0.22F)/Settings.scale, 40F),
-                    new GremlinRiderRed((Settings.WIDTH * -0.32F)/Settings.scale, -60F),
+                        new GremlinRiderRed((Settings.WIDTH * -0.32F)/Settings.scale, -60F),
+                        new GremlinRiderRed((Settings.WIDTH * -0.22F)/Settings.scale, 40F),
                         new GremlinCannon((Chest.CHEST_LOC_X - Settings.WIDTH*0.75F)/Settings.scale,
                                 (Chest.CHEST_LOC_Y - AbstractDungeon.floorY - 256.0F*Settings.scale)/Settings.yScale)
                 })));

--- a/src/main/java/spireMapOverhaul/zones/gremlinTown/GremlinTown.java
+++ b/src/main/java/spireMapOverhaul/zones/gremlinTown/GremlinTown.java
@@ -398,7 +398,7 @@ public class GremlinTown extends AbstractZone
                 item.text = item.potion.name;
             }
 
-            if (item.type == RewardItem.RewardType.RELIC) {
+            if (item.type == RewardItem.RewardType.RELIC && Wiz.isNormalRelicTier(item.relic.tier)) {
                 item.relic = getRandomGRelic();
                 item.text = item.relic.name;
             }

--- a/src/main/java/spireMapOverhaul/zones/gremlinTown/monsters/GremlinRiderRed.java
+++ b/src/main/java/spireMapOverhaul/zones/gremlinTown/monsters/GremlinRiderRed.java
@@ -3,6 +3,7 @@ package spireMapOverhaul.zones.gremlinTown.monsters;
 import basemod.abstracts.CustomMonster;
 import com.badlogic.gdx.math.MathUtils;
 import com.esotericsoftware.spine.AnimationState;
+import com.evacipated.cardcrawl.mod.stslib.patches.NeutralPowertypePatch;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.animations.AnimateSlowAttackAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
@@ -11,6 +12,8 @@ import com.megacrit.cardcrawl.actions.utility.WaitAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.localization.MonsterStrings;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.powers.GainStrengthPower;
 import com.megacrit.cardcrawl.powers.StrengthPower;
 import spireMapOverhaul.SpireAnniversary6Mod;
 
@@ -85,10 +88,16 @@ public class GremlinRiderRed extends CustomMonster
                 atb(new AnimateSlowAttackAction(this));
                 atb(new DamageAction(adp(), damage.get(1), AbstractGameAction.AttackEffect.SLASH_DIAGONAL));
                 atb(new WaitAction(0.1f));
-                if (asc() < 17)
+                if (asc() < 17) {
                     applyToEnemy(this, new StrengthPower(this, TACTICAL_STRENGTH));
-                else
-                    forAllMonstersLiving(m -> applyToEnemy(m, new StrengthPower(m, TACTICAL_STRENGTH_A17)));
+                }
+                else {
+                    forAllMonstersLiving(m ->  {
+                        AbstractPower gainStrength = new GainStrengthPower(m, TACTICAL_STRENGTH_A17);
+                        gainStrength.type = NeutralPowertypePatch.NEUTRAL;
+                        applyToEnemy(m, gainStrength);
+                    });
+                }
         }
         atb(new RollMoveAction(this));
     }

--- a/src/main/java/spireMapOverhaul/zones/invasion/InvasionZone.java
+++ b/src/main/java/spireMapOverhaul/zones/invasion/InvasionZone.java
@@ -16,6 +16,7 @@ import com.megacrit.cardcrawl.rooms.MonsterRoomElite;
 import spireMapOverhaul.SpireAnniversary6Mod;
 import spireMapOverhaul.abstracts.AbstractZone;
 import spireMapOverhaul.util.ActUtil;
+import spireMapOverhaul.util.Wiz;
 import spireMapOverhaul.zoneInterfaces.EncounterModifyingZone;
 import spireMapOverhaul.zoneInterfaces.RewardModifyingZone;
 import spireMapOverhaul.zoneInterfaces.ShopModifyingZone;
@@ -104,7 +105,7 @@ public class InvasionZone extends AbstractZone implements EncounterModifyingZone
     @Override
     public void modifyRewards(ArrayList<RewardItem> rewards) {
         for (int i = 0; i < rewards.size(); i++) {
-            if (rewards.get(i).type == RewardItem.RewardType.RELIC) {
+            if (rewards.get(i).type == RewardItem.RewardType.RELIC && Wiz.isNormalRelicTier(rewards.get(i).relic.tier)) {
                 RewardItem rewardItem = new RewardItem();
                 rewardItem.cards = InvasionUtil.getRewardCards(this.getNumberOfCardsInReward());
                 //Note that this reward does not get the normal act-dependent chance of cards being upgraded


### PR DESCRIPTION
* Various zones: skip special relics when modifying rewards for Broken Space, Candy Land, Grass, Gremlin Town, and Invasion zones
* Gremlin Town zone: fix enemies in the chest fight attacking in the wrong order
* Gremlin Town zone: change the red gremlin rider's strength buffing move so that the strength is gained at the end of the monster round in order to avoid intent damage changing
* Broken Space zone: preserve unreadability for cards generated by Broken Snecko Eye if the player manages to keep them around (e.g. by discarding them)
* Frostlands zone: prevent softlocks and other issues caused by the Contraption relic activating