### PR TITLE
Monster Zoo/Wildfire zones: change how the rooms are placed to avoid reducing the total number of non-monster rooms on the map

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/monsterZoo/MonsterZooZone.java
+++ b/src/main/java/spireMapOverhaul/zones/monsterZoo/MonsterZooZone.java
@@ -11,12 +11,15 @@ import com.megacrit.cardcrawl.monsters.city.Byrd;
 import com.megacrit.cardcrawl.powers.StrengthPower;
 import com.megacrit.cardcrawl.random.Random;
 import com.megacrit.cardcrawl.rewards.RewardItem;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.rooms.MonsterRoom;
 import spireMapOverhaul.abstracts.AbstractZone;
 import spireMapOverhaul.util.Wiz;
 import spireMapOverhaul.zoneInterfaces.CombatModifyingZone;
 import spireMapOverhaul.zoneInterfaces.RenderableZone;
 import spireMapOverhaul.zoneInterfaces.RewardModifyingZone;
+
+import java.util.ArrayList;
 
 public class MonsterZooZone extends AbstractZone implements RewardModifyingZone, CombatModifyingZone, RenderableZone {
     public static final String ID = "MonsterZoo";
@@ -39,12 +42,18 @@ public class MonsterZooZone extends AbstractZone implements RewardModifyingZone,
     }
 
     @Override
-    public void replaceRooms(Random rng) {
-        //Replace all non monster rooms with monster rooms
-        for (MapRoomNode node : this.nodes) {
-            if(!(node.room instanceof MonsterRoom)) { //Replaces shop/rest/event with normal monster room
-                node.setRoom(new MonsterRoom());
-            }
+    public void distributeRooms(Random rng, ArrayList<AbstractRoom> roomList) {
+        // This fills the zone with monster rooms, with half taken from the room distribution list (which means they
+        // could be elite rooms instead of normal monster rooms, and that it uses up some of the expected distribution
+        // of those room types), and half simply set directly (which means they are always normal monster rooms and do
+        // not use up any of the expected distribution of those room types)
+        int half = nodes.size() / 2;
+        int i;
+        for (i = 0; i < half; ++i) {
+            nodes.get(i).setRoom(roomOrDefault(roomList, (room) -> room instanceof MonsterRoom, MonsterRoom::new));
+        }
+        for (; i < nodes.size(); ++i) {
+            nodes.get(i).setRoom(new MonsterRoom());
         }
     }
 

--- a/src/main/java/spireMapOverhaul/zones/wildfire/Wildfire.java
+++ b/src/main/java/spireMapOverhaul/zones/wildfire/Wildfire.java
@@ -13,9 +13,7 @@ import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.map.MapRoomNode;
 import com.megacrit.cardcrawl.random.Random;
-import com.megacrit.cardcrawl.rooms.EventRoom;
-import com.megacrit.cardcrawl.rooms.MonsterRoom;
-import com.megacrit.cardcrawl.rooms.ShopRoom;
+import com.megacrit.cardcrawl.rooms.*;
 import spireMapOverhaul.abstracts.AbstractZone;
 import spireMapOverhaul.util.Wiz;
 import spireMapOverhaul.zoneInterfaces.CombatModifyingZone;
@@ -107,12 +105,16 @@ public class Wildfire extends AbstractZone implements CombatModifyingZone, Rewar
     }
 
     @Override
-    public void replaceRooms(Random rng) {
-        //Replace all event and shop rooms with monster rooms
-        for (MapRoomNode node : this.nodes) {
-            if (node.room != null && (EventRoom.class.equals(node.room.getClass()) || ShopRoom.class.equals(node.room.getClass()))) {
-                node.setRoom(new MonsterRoom());
-            }
+    public void distributeRooms(Random rng, ArrayList<AbstractRoom> roomList) {
+        // This makes all rooms in the zone either monster rooms (which could be elites) or campfires.
+        // See the comment in Monster Zoo's distributeRooms method for a more detailed explanation of this approach.
+        int half = nodes.size() / 2;
+        int i;
+        for (i = 0; i < half; ++i) {
+            nodes.get(i).setRoom(roomOrDefault(roomList, (room) -> room instanceof MonsterRoom || room instanceof RestRoom, MonsterRoom::new));
+        }
+        for (; i < nodes.size(); ++i) {
+            nodes.get(i).setRoom(new MonsterRoom());
         }
     }
 


### PR DESCRIPTION
This something Alch brought up. See https://discord.com/channels/309399445785673728/398373038732738570/1217272840227917894 for the suggestion he made (there's some context before that and some discussion after it as well). The short version is that this will have less impact on the overall distribution of room types than the previous code.

It seemed like a reasonable change to make, so I implemented it and did a bit of testing to make sure that this works properly (specifically making sure that elite rooms sometimes show up in either zones, and that campfires sometimes show up for Wildfire).

Leaving this for you to look over and merge.