### PR TITLE
Smith's Folly: Biome no longer guarantees an event

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/smithsFolly/SmithsFolly.java
+++ b/src/main/java/spireMapOverhaul/zones/smithsFolly/SmithsFolly.java
@@ -32,7 +32,7 @@ public class SmithsFolly extends AbstractZone implements CombatModifyingZone, On
     public SmithsFolly() {
         super(ID, Icons.MONSTER);
         this.width = 2;
-        this.height = 5;
+        this.height = 4;
     }
 
     @Override

--- a/src/main/java/spireMapOverhaul/zones/smithsFolly/SmithsFolly.java
+++ b/src/main/java/spireMapOverhaul/zones/smithsFolly/SmithsFolly.java
@@ -32,7 +32,7 @@ public class SmithsFolly extends AbstractZone implements CombatModifyingZone, On
     public SmithsFolly() {
         super(ID, Icons.MONSTER);
         this.width = 2;
-        this.height = 4;
+        this.height = 5;
     }
 
     @Override
@@ -48,11 +48,6 @@ public class SmithsFolly extends AbstractZone implements CombatModifyingZone, On
     @Override
     public boolean canSpawn() {
         return !this.isAct(2);
-    }
-
-    @Override
-    public void distributeRooms(com.megacrit.cardcrawl.random.Random rng, ArrayList<AbstractRoom> roomList) {
-        placeRoomRandomly(rng, roomOrDefault(roomList, (room)->room instanceof EventRoom, EventRoom::new));
     }
 
     @Override


### PR DESCRIPTION
Two free upgrades is highly valuable, and the events that Smith's Folly can generate are also very powerful. It also opens up another pathing option for those going for the Emerald Key. Previously, it was too easy to reap the rewards of the biome without punishment. This change should increase likelihood of combat encounters in the biome, making the decision to path here a bit less obvious.