### PR TITLE
Volatile Grounds Bestiary entries and bug fixes

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/Eruptor.java
+++ b/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/Eruptor.java
@@ -92,13 +92,13 @@ public class Eruptor extends CustomMonster {
     @Override
     protected void getMove(final int num) {
         if (this.firstMove) {
-            this.setMove(BRUISE, Intent.ATTACK, attackDamage);
+            this.setMove(MOVES[0], BRUISE, Intent.ATTACK, attackDamage);
             this.firstMove = false;
         } else {
             if (this.lastMove(BRUISE)) {
-                this.setMove(BOIL, Intent.DEBUFF);
+                this.setMove(MOVES[1], BOIL, Intent.DEBUFF);
             } else {
-                this.setMove(BRUISE, Intent.ATTACK, attackDamage);
+                this.setMove(MOVES[0], BRUISE, Intent.ATTACK, attackDamage);
             }
         }
     }

--- a/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/GremlinArchmage.java
+++ b/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/GremlinArchmage.java
@@ -62,14 +62,14 @@ public class GremlinArchmage extends CustomMonster {
         } else {
             this.setHp(HP_MIN, HP_MAX);
         }
-        if(AbstractDungeon.ascensionLevel <= 3) {
+        if(AbstractDungeon.ascensionLevel >= 2) {
             this.damage.add(new DamageInfo(this, ATTACK_DAMAGE_1));
-            damage1 = A2_ATTACK_DAMAGE_1;
+            damage1 = ATTACK_DAMAGE_1;
         }
         else
         {
             this.damage.add(new DamageInfo(this, A2_ATTACK_DAMAGE_1));
-            damage1 = ATTACK_DAMAGE_1;
+            damage1 = A2_ATTACK_DAMAGE_1;
         }
         if(AbstractDungeon.ascensionLevel >= 17)
         {

--- a/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/GremlinArchmage.java
+++ b/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/GremlinArchmage.java
@@ -152,13 +152,13 @@ public class GremlinArchmage extends CustomMonster {
     protected void getMove(final int num) {
         if(canSpawn() && !lastMove(SUMMON))
         {
-            this.setMove(SUMMON, Intent.UNKNOWN);
+            this.setMove(MOVES[0], SUMMON, Intent.UNKNOWN);
         }
         else if ((num < 50 && !lastTwoMoves(ATTACK) && !firstTurn) || lastTwoMoves(BLOCK)) {
-            this.setMove(ATTACK, Intent.ATTACK, damage1);
+            this.setMove(MOVES[1], ATTACK, Intent.ATTACK, damage1);
         
         } else {
-            this.setMove(BLOCK, Intent.DEFEND);
+            this.setMove(MOVES[2], BLOCK, Intent.DEFEND);
         }
         firstTurn = false;
     }

--- a/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/HeatBlister.java
+++ b/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/HeatBlister.java
@@ -81,8 +81,10 @@ public class HeatBlister extends CustomMonster {
                         new ExplodePlusPower(this, A17_EXPLOSION_COUNTDOWN,
                         A2_EXPLOSION_DAMAGE)));
             }
-            AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(this, this, new ExplodePlusPower(this, EXPLOSION_COUNTDOWN,
-                    A2_EXPLOSION_DAMAGE)));
+            else {
+                AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(this, this, new ExplodePlusPower(this, EXPLOSION_COUNTDOWN,
+                        A2_EXPLOSION_DAMAGE)));
+            }
         }
         else
         {

--- a/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/HeatBlister.java
+++ b/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/HeatBlister.java
@@ -100,7 +100,7 @@ public class HeatBlister extends CustomMonster {
                 break;
             case ATTACK_AND_DEBUFF:
                 AbstractDungeon.actionManager.addToBottom(new AnimateFastAttackAction(this));
-                AbstractDungeon.actionManager.addToBottom(new DamageAction(AbstractDungeon.player, this.damage.get(0), AbstractGameAction.AttackEffect.FIRE));
+                AbstractDungeon.actionManager.addToBottom(new DamageAction(AbstractDungeon.player, this.damage.get(1), AbstractGameAction.AttackEffect.FIRE));
                 AbstractDungeon.actionManager.addToBottom(new MakeTempCardInDiscardAction(new Slimed(), 1));
                 Burn burn = new Burn();
                 if(AbstractDungeon.ascensionLevel >= 17) {

--- a/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/SunStoneShard.java
+++ b/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/SunStoneShard.java
@@ -108,12 +108,12 @@ public class SunStoneShard extends CustomMonster {
     @Override
     protected void getMove(final int num) {
         if (!lastMove(BUFF) && !lastMoveBefore(BUFF)) {
-            this.setMove(BUFF, Intent.BUFF);
+            this.setMove(MOVES[0], BUFF, Intent.BUFF);
         } else {
             if ((num > 50 && lastMove(BUFF)) || lastMove(BARRIER)) {
-                this.setMove(ATTACK, Intent.ATTACK, attackDamage);
+                this.setMove(MOVES[1], ATTACK, Intent.ATTACK, attackDamage);
             } else {
-                this.setMove(BARRIER, Intent.DEFEND_BUFF);
+                this.setMove(MOVES[2], BARRIER, Intent.DEFEND_BUFF);
             }
         }
     }

--- a/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/UnstableSunstone.java
+++ b/src/main/java/spireMapOverhaul/zones/volatileGrounds/monsters/UnstableSunstone.java
@@ -108,12 +108,12 @@ public class UnstableSunstone extends CustomMonster {
     @Override
     protected void getMove(final int num) {
         if (this.firstMove && AbstractDungeon.ascensionLevel < 18) {
-            this.setMove(BUFF, Intent.BUFF);
+            this.setMove(MOVES[2], BUFF, Intent.BUFF);
         } else {
             if (this.lastMove(ATTACK2) || firstMove) {
-                this.setMove(ATTACK1, Intent.ATTACK, damage1);
+                this.setMove(MOVES[0], ATTACK1, Intent.ATTACK, damage1);
             } else {
-                this.setMove(ATTACK2, Intent.ATTACK_DEBUFF, damage2);
+                this.setMove(MOVES[1], ATTACK2, Intent.ATTACK_DEBUFF, damage2);
             }
         }
         this.firstMove = false;

--- a/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
+++ b/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
@@ -299,7 +299,7 @@
 					"notes": "Exploders start with 75% HP.",
 					"moves": [
 						{
-							"name": "Summon",
+							"name": "Summon Shapes",
 							"effects": [
 								{
 									"name": "Spawn Exploders (up to 2 total)",
@@ -308,7 +308,7 @@
 							]
 						},
 						{
-							"name": "Attack",
+							"name": "Fireball",
 							"effects": [
 								{
 									"name": "12",
@@ -317,7 +317,7 @@
 							]
 						},
 						{
-							"name": "Block",
+							"name": "Mage Armor",
 							"effects": [
 								{
 									"name": "Party Block 8",

--- a/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
+++ b/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
@@ -118,7 +118,7 @@
 					"min_asc": 0,
 					"desc": "Starts with #wBuff, then repeats a 50% chance to use #wAttack or #wAttack #wand #wDebuff. Cannot use the same move three times in a row.",
 					"hp": "(100 - 110 HP)",
-					"notes": "Innate #uExplode+ #u5 for #r40 damage.",
+					"notes": "Innate #uExplode+ #u5 for #r40 damage. #dSlimed and #dBurn status cards go into the discard pile.",
 					"moves": [
 						{
 							"name": "Buff",
@@ -161,7 +161,7 @@
 					"min_asc": 2,
 					"desc": "Starts with #wBuff, then repeats a 50% chance to use #wAttack or #wAttack #wand #wDebuff. Cannot use the same move three times in a row.",
 					"hp": "(100 - 110 HP)",
-					"notes": "Innate #uExplode+ #u5 for #r50 damage.",
+					"notes": "Innate #uExplode+ #u5 for #r50 damage. #dSlimed and #dBurn status cards go into the discard pile.",
 					"moves": [
 						{
 							"name": "Buff",
@@ -204,7 +204,7 @@
 					"min_asc": 7,
 					"desc": "Starts with #wBuff, then repeats a 50% chance to use #wAttack or #wAttack #wand #wDebuff. Cannot use the same move three times in a row.",
 					"hp": "(110 - 120 HP)",
-					"notes": "Innate #uExplode+ #u5 for #r50 damage.",
+					"notes": "Innate #uExplode+ #u5 for #r50 damage. #dSlimed and #dBurn status cards go into the discard pile.",
 					"moves": [
 						{
 							"name": "Buff",
@@ -247,7 +247,7 @@
 					"min_asc": 17,
 					"desc": "Starts with #wBuff, then repeats a 50% chance to use #wAttack or #wAttack #wand #wDebuff. Cannot use the same move three times in a row.",
 					"hp": "(110 - 120 HP)",
-					"notes": "Innate #uExplode+ #u4 for #r50 damage.",
+					"notes": "Innate #uExplode+ #u4 for #r50 damage. #dSlimed and #dBurn status cards go into the discard pile.",
 					"moves": [
 						{
 							"name": "Buff",

--- a/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
+++ b/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
@@ -433,6 +433,168 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Sun Stone Shard",
+			"id": "${ModID}:SunStoneShard",
+			"ai": [
+				{
+					"min_asc": 0,
+					"desc": "Cycles #wCharge -> #wSear or #wBarrier -> the other.",
+					"hp": "(60 - 65 HP)",
+					"notes": "Innate #uCharged #u5.",
+					"moves": [
+						{
+							"name": "Charge",
+							"effects": [
+								{
+									"name": "Charge 3",
+									"color": "BUFF"
+								}
+							]
+						},
+						{
+							"name": "Sear",
+							"effects": [
+								{
+									"name": "7",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Barrier",
+							"effects": [
+								{
+									"name": "5",
+									"color": "BLOCK"
+								},
+								{
+									"name": "Flame Barrier 5",
+									"color": "BUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 3,
+					"desc": "Cycles #wCharge -> #wSear or #wBarrier -> the other.",
+					"hp": "(60 - 65 HP)",
+					"notes": "Innate #uCharged #u8.",
+					"moves": [
+						{
+							"name": "Charge",
+							"effects": [
+								{
+									"name": "Charge 3",
+									"color": "BUFF"
+								}
+							]
+						},
+						{
+							"name": "Sear",
+							"effects": [
+								{
+									"name": "9",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Barrier",
+							"effects": [
+								{
+									"name": "5",
+									"color": "BLOCK"
+								},
+								{
+									"name": "Flame Barrier 5",
+									"color": "BUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 8,
+					"desc": "Cycles #wCharge -> #wSear or #wBarrier -> the other.",
+					"hp": "(75 - 85 HP)",
+					"notes": "Innate #uCharged #u8.",
+					"moves": [
+						{
+							"name": "Charge",
+							"effects": [
+								{
+									"name": "Charge 3",
+									"color": "BUFF"
+								}
+							]
+						},
+						{
+							"name": "Sear",
+							"effects": [
+								{
+									"name": "9",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Barrier",
+							"effects": [
+								{
+									"name": "5",
+									"color": "BLOCK"
+								},
+								{
+									"name": "Flame Barrier 5",
+									"color": "BUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 18,
+					"desc": "Cycles #wCharge -> #wSear or #wBarrier -> the other.",
+					"hp": "(75 - 85 HP)",
+					"notes": "Innate #uCharged #u8.",
+					"moves": [
+						{
+							"name": "Charge",
+							"effects": [
+								{
+									"name": "Charge 5",
+									"color": "BUFF"
+								}
+							]
+						},
+						{
+							"name": "Sear",
+							"effects": [
+								{
+									"name": "9",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Barrier",
+							"effects": [
+								{
+									"name": "5",
+									"color": "BLOCK"
+								},
+								{
+									"name": "Flame Barrier 8",
+									"color": "BUFF"
+								}
+							]
+						}
+					]
+				}
+			]
 		}
 	]
 }

--- a/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
+++ b/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
@@ -287,6 +287,152 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Gremlin Archmage",
+			"id": "${ModID}:GremlinArchmage",
+			"ai": [
+				{
+					"min_asc": 0,
+					"desc": "Starts with #wBlock. Then, if there are zero or one Exploders left and the last move wasn't #wSummon, uses #wSummon. Otherwise, 50% chance to use #wAttack or #wBlock. Cannot use the same move three times in a row.",
+					"hp": "(95 - 98 HP)",
+					"notes": "Exploders start with 75% HP.",
+					"moves": [
+						{
+							"name": "Summon",
+							"effects": [
+								{
+									"name": "Spawn Exploders (up to 2 total)",
+									"color": "SPECIAL"
+								}
+							]
+						},
+						{
+							"name": "Attack",
+							"effects": [
+								{
+									"name": "12",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Block",
+							"effects": [
+								{
+									"name": "Party Block 8",
+									"color": "BLOCK"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 2,
+					"desc": "Starts with #wBlock. Then, if there are zero or one Exploders left and the last move wasn't #wSummon, uses #wSummon. Otherwise, 50% chance to use #wAttack or #wBlock. Cannot use the same move three times in a row.",
+					"hp": "(95 - 98 HP)",
+					"notes": "Exploders start with 75% HP.",
+					"moves": [
+						{
+							"name": "Summon",
+							"effects": [
+								{
+									"name": "Spawn Exploders (up to 2 total)",
+									"color": "SPECIAL"
+								}
+							]
+						},
+						{
+							"name": "Attack",
+							"effects": [
+								{
+									"name": "14",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Block",
+							"effects": [
+								{
+									"name": "Party Block 8",
+									"color": "BLOCK"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 7,
+					"desc": "Starts with #wBlock. Then, if there are zero or one Exploders left and the last move wasn't #wSummon, uses #wSummon. Otherwise, 50% chance to use #wAttack or #wBlock. Cannot use the same move three times in a row.",
+					"hp": "(110 - 115 HP)",
+					"notes": "Exploders start with 75% HP.",
+					"moves": [
+						{
+							"name": "Summon",
+							"effects": [
+								{
+									"name": "Spawn Exploders (up to 2 total)",
+									"color": "SPECIAL"
+								}
+							]
+						},
+						{
+							"name": "Attack",
+							"effects": [
+								{
+									"name": "14",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Block",
+							"effects": [
+								{
+									"name": "Party Block 8",
+									"color": "BLOCK"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 17,
+					"desc": "Starts with #wBlock. Then, if there are zero or one Exploders left and the last move wasn't #wSummon, uses #wSummon. Otherwise, 50% chance to use #wAttack or #wBlock. Cannot use the same move three times in a row.",
+					"hp": "(110 - 115 HP)",
+					"notes": "Exploders start with 75% HP and 3 strength.",
+					"moves": [
+						{
+							"name": "Summon",
+							"effects": [
+								{
+									"name": "Spawn Exploders (up to 2 total)",
+									"color": "SPECIAL"
+								}
+							]
+						},
+						{
+							"name": "Attack",
+							"effects": [
+								{
+									"name": "14",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Block",
+							"effects": [
+								{
+									"name": "Party Block 12",
+									"color": "BLOCK"
+								}
+							]
+						}
+					]
+				}
+			]
 		}
 	]
 }

--- a/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
+++ b/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
@@ -109,6 +109,184 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Heat Blister",
+			"id": "${ModID}:HeatBlister",
+			"ai": [
+				{
+					"min_asc": 0,
+					"desc": "Starts with #wBuff, then repeats a 50% chance to use #wAttack or #wAttack #wand #wDebuff. Cannot use the same move three times in a row.",
+					"hp": "(100 - 110 HP)",
+					"notes": "Innate #uExplode+ #u5 for #r40 damage.",
+					"moves": [
+						{
+							"name": "Buff",
+							"effects": [
+								{
+									"name": "Malleable 3",
+									"color": "BUFF"
+								}
+							]
+						},
+						{
+							"name": "Attack",
+							"effects": [
+								{
+									"name": "15",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Attack and Debuff",
+							"effects": [
+								{
+									"name": "5",
+									"color": "DAMAGE"
+								},
+								{
+									"name": "Slimed 1",
+									"color": "DEBUFF"
+								},
+								{
+									"name": "Burn 1",
+									"color": "DEBUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 2,
+					"desc": "Starts with #wBuff, then repeats a 50% chance to use #wAttack or #wAttack #wand #wDebuff. Cannot use the same move three times in a row.",
+					"hp": "(100 - 110 HP)",
+					"notes": "Innate #uExplode+ #u5 for #r50 damage.",
+					"moves": [
+						{
+							"name": "Buff",
+							"effects": [
+								{
+									"name": "Malleable 3",
+									"color": "BUFF"
+								}
+							]
+						},
+						{
+							"name": "Attack",
+							"effects": [
+								{
+									"name": "18",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Attack and Debuff",
+							"effects": [
+								{
+									"name": "8",
+									"color": "DAMAGE"
+								},
+								{
+									"name": "Slimed 1",
+									"color": "DEBUFF"
+								},
+								{
+									"name": "Burn 1",
+									"color": "DEBUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 7,
+					"desc": "Starts with #wBuff, then repeats a 50% chance to use #wAttack or #wAttack #wand #wDebuff. Cannot use the same move three times in a row.",
+					"hp": "(110 - 120 HP)",
+					"notes": "Innate #uExplode+ #u5 for #r50 damage.",
+					"moves": [
+						{
+							"name": "Buff",
+							"effects": [
+								{
+									"name": "Malleable 3",
+									"color": "BUFF"
+								}
+							]
+						},
+						{
+							"name": "Attack",
+							"effects": [
+								{
+									"name": "18",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Attack and Debuff",
+							"effects": [
+								{
+									"name": "8",
+									"color": "DAMAGE"
+								},
+								{
+									"name": "Slimed 1",
+									"color": "DEBUFF"
+								},
+								{
+									"name": "Burn 1",
+									"color": "DEBUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 17,
+					"desc": "Starts with #wBuff, then repeats a 50% chance to use #wAttack or #wAttack #wand #wDebuff. Cannot use the same move three times in a row.",
+					"hp": "(110 - 120 HP)",
+					"notes": "Innate #uExplode+ #u4 for #r50 damage.",
+					"moves": [
+						{
+							"name": "Buff",
+							"effects": [
+								{
+									"name": "Malleable 3",
+									"color": "BUFF"
+								}
+							]
+						},
+						{
+							"name": "Attack",
+							"effects": [
+								{
+									"name": "18",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Attack and Debuff",
+							"effects": [
+								{
+									"name": "8",
+									"color": "DAMAGE"
+								},
+								{
+									"name": "Slimed 1",
+									"color": "DEBUFF"
+								},
+								{
+									"name": "Burn+ 1",
+									"color": "DEBUFF"
+								}
+							]
+						}
+					]
+				}
+			]
 		}
 	]
 }

--- a/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
+++ b/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
@@ -595,6 +595,159 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Unstable Sunstone",
+			"id": "${ModID}:UnstableSunstone",
+			"ai": [
+				{
+					"min_asc": 0,
+					"desc": "Starts with #wHot #wPotato, then cycles #wSear -> #wDestabilize.",
+					"hp": "(110 - 120 HP)",
+					"notes": "#dBurn status cards go into the hand.",
+					"moves": [
+						{
+							"name": "Destabilize",
+							"effects": [
+								{
+									"name": "10",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Sear",
+							"effects": [
+								{
+									"name": "5",
+									"color": "DAMAGE"
+								},
+								{
+									"name": "Burn 1",
+									"color": "DEBUFF"
+								}
+							]
+						},
+						{
+							"name": "Hot Potato",
+							"effects": [
+								{
+									"name": "Unstable 6",
+									"color": "BUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 3,
+					"desc": "Starts with #wHot #wPotato, then cycles #wSear -> #wDestabilize.",
+					"hp": "(110 - 120 HP)",
+					"notes": "#dBurn status cards go into the hand.",
+					"moves": [
+						{
+							"name": "Destabilize",
+							"effects": [
+								{
+									"name": "12",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Sear",
+							"effects": [
+								{
+									"name": "6",
+									"color": "DAMAGE"
+								},
+								{
+									"name": "Burn 1",
+									"color": "DEBUFF"
+								}
+							]
+						},
+						{
+							"name": "Hot Potato",
+							"effects": [
+								{
+									"name": "Unstable 10",
+									"color": "BUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 8,
+					"desc": "Starts with #wHot #wPotato, then cycles #wSear -> #wDestabilize.",
+					"hp": "(140 - 155 HP)",
+					"notes": "#dBurn status cards go into the hand.",
+					"moves": [
+						{
+							"name": "Destabilize",
+							"effects": [
+								{
+									"name": "12",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Sear",
+							"effects": [
+								{
+									"name": "6",
+									"color": "DAMAGE"
+								},
+								{
+									"name": "Burn 1",
+									"color": "DEBUFF"
+								}
+							]
+						},
+						{
+							"name": "Hot Potato",
+							"effects": [
+								{
+									"name": "Unstable 10",
+									"color": "BUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 18,
+					"desc": "Cycles #wDestabilize -> #wSear.",
+					"hp": "(140 - 155 HP)",
+					"notes": "Innate #uUnstable #u10. #dBurn status cards go into the draw pile.",
+					"moves": [
+						{
+							"name": "Destabilize",
+							"effects": [
+								{
+									"name": "12",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Sear",
+							"effects": [
+								{
+									"name": "6",
+									"color": "DAMAGE"
+								},
+								{
+									"name": "Burn 1",
+									"color": "DEBUFF"
+								}
+							]
+						}
+					]
+				}
+			]
 		}
 	]
 }

--- a/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
+++ b/src/main/resources/anniv6Resources/bestiary/eng/VolatileGrounds/bestiary.json
@@ -1,0 +1,114 @@
+{
+	"monsters": [
+		{
+			"name": "Eruptor",
+			"id": "${ModID}:Eruptor",
+			"ai": [
+				{
+					"min_asc": 0,
+					"desc": "Cycles #wBruise -> #wBoil.",
+					"hp": "(22 - 26 HP)",
+					"notes": "Innate #uErupt #u15 for #r15 damage. #dBurn status cards go into the draw pile.",
+					"moves": [
+						{
+							"name": "Bruise",
+							"effects": [
+								{
+									"name": "6",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Boil",
+							"effects": [
+								{
+									"name": "Burn 1",
+									"color": "DEBUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 2,
+					"desc": "Cycles #wBruise -> #wBoil.",
+					"hp": "(22 - 26 HP)",
+					"notes": "Innate #uErupt #u15 for #r20 damage. #dBurn status cards go into the draw pile.",
+					"moves": [
+						{
+							"name": "Bruise",
+							"effects": [
+								{
+									"name": "8",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Boil",
+							"effects": [
+								{
+									"name": "Burn 1",
+									"color": "DEBUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 7,
+					"desc": "Cycles #wBruise -> #wBoil.",
+					"hp": "(25 - 30 HP)",
+					"notes": "Innate #uErupt #u15 for #r20 damage. #dBurn status cards go into the draw pile.",
+					"moves": [
+						{
+							"name": "Bruise",
+							"effects": [
+								{
+									"name": "8",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Boil",
+							"effects": [
+								{
+									"name": "Burn 1",
+									"color": "DEBUFF"
+								}
+							]
+						}
+					]
+				},
+				{
+					"min_asc": 17,
+					"desc": "Cycles #wBruise -> #wBoil.",
+					"hp": "(25 - 30 HP)",
+					"notes": "Innate #uErupt #u10 for #r20 damage. #dBurn status cards go into the draw pile.",
+					"moves": [
+						{
+							"name": "Bruise",
+							"effects": [
+								{
+									"name": "8",
+									"color": "DAMAGE"
+								}
+							]
+						},
+						{
+							"name": "Boil",
+							"effects": [
+								{
+									"name": "Burn 1",
+									"color": "DEBUFF"
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
I noticed a few issues with the enemies while making Bestiary entries for Volatile Grounds, so I fixed them along the way.

Here are the key changes:
* Bestiary: add Volatile Grounds entries
* Volatile Grounds zone: show names for most enemy moves
* Volatile Grounds zone: fix Heat Blister's attack and debuff doing the wrong amount of damage
* Volatile Grounds zone: fix Heat Blister having the wrong explode amount on A17+
* Volatile Grounds zone: fix Gremlin Archmage having a mismatch between the damage it dealt and the damage shown in its intent