### PR TITLE
Add safeguards to prevent zones that buff or debuff monsters from crashing if there's a fight that starts without monsters

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/gremlincamp/GremlinCamp.java
+++ b/src/main/java/spireMapOverhaul/zones/gremlincamp/GremlinCamp.java
@@ -122,6 +122,9 @@ public class GremlinCamp extends AbstractZone implements EncounterModifyingZone,
 
     @Override
     public void atPreBattle() {
+        if (AbstractDungeon.getCurrRoom().monsters == null) {
+            return;
+        }
         if (GET_DOWN_MR_PRESIDENT.equals(AbstractDungeon.lastCombatMetricKey)) {
             // President starts with 1 Buffer
             for (AbstractMonster m : AbstractDungeon.getCurrRoom().monsters.monsters) {

--- a/src/main/java/spireMapOverhaul/zones/monsterZoo/MonsterZooZone.java
+++ b/src/main/java/spireMapOverhaul/zones/monsterZoo/MonsterZooZone.java
@@ -126,6 +126,9 @@ public class MonsterZooZone extends AbstractZone implements RewardModifyingZone,
     // All monsters gain an amount of strength
     @Override
     public void atPreBattle() {
+        if (AbstractDungeon.getCurrRoom().monsters == null) {
+            return;
+        }
         Wiz.forAllMonstersLiving(m -> Wiz.atb(new ApplyPowerAction(m, null, new StrengthPower(m, getStrAmt(m)))));
     }
 

--- a/src/main/java/spireMapOverhaul/zones/smithsFolly/SmithsFolly.java
+++ b/src/main/java/spireMapOverhaul/zones/smithsFolly/SmithsFolly.java
@@ -84,6 +84,9 @@ public class SmithsFolly extends AbstractZone implements CombatModifyingZone, On
 
     @Override
     public void atPreBattle() {
+        if (AbstractDungeon.getCurrRoom().monsters == null) {
+            return;
+        }
         if (!AbstractDungeon.getCurrMapNode().hasEmeraldKey) {
             AbstractRoom abstractRoom = AbstractDungeon.getCurrRoom();
 

--- a/src/main/java/spireMapOverhaul/zones/thefog/TheFogZone.java
+++ b/src/main/java/spireMapOverhaul/zones/thefog/TheFogZone.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.MakeTempCardInDrawPileAction;
 import com.megacrit.cardcrawl.cards.status.Dazed;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.map.MapRoomNode;
 import com.megacrit.cardcrawl.powers.VulnerablePower;
 import com.megacrit.cardcrawl.powers.WeakPower;
@@ -37,6 +38,9 @@ public class TheFogZone extends AbstractZone implements CombatModifyingZone, Mod
 
     @Override
     public void atPreBattle() {
+        if (AbstractDungeon.getCurrRoom().monsters == null) {
+            return;
+        }
         forAllMonstersLiving(m -> {
             atb(new ApplyPowerAction(m, null, new WeakPower(m, 1, false)));
             atb(new ApplyPowerAction(m, null, new VulnerablePower(m, 1, false)));


### PR DESCRIPTION
The intent of this is to avoid crashes such as 
https://discord.com/channels/309399445785673728/724725673578463232/1229505634186301490. It's unclear what the root cause of this crash is (my best guess is some mod that messes with combats), so rather than try work out which of the billion mods it might be, I'm fixing the immediate symptom that causes the crash. The best case is that this fully fixes things. If not, it may let people get further along in the room loading process and get more information that could lead to the root cause.