### PR TITLE
Changed rendering logic for zones on the map

### DIFF
--- a/src/main/java/spireMapOverhaul/abstracts/AbstractZone.java
+++ b/src/main/java/spireMapOverhaul/abstracts/AbstractZone.java
@@ -77,7 +77,7 @@ public abstract class AbstractZone {
     protected float labelX = 0, labelY = 0;
 
     public FrameBuffer zoneFb = null;
-    private TextureRegion shapeRegion = null;
+    public TextureRegion shapeRegion = null;
     public Texture iconTexture;
 
     public List<Hitbox> hitboxes;
@@ -212,12 +212,9 @@ public abstract class AbstractZone {
             float anchorX = x * SPACING_X + OFFSET_X - ZoneShapeMaker.FB_OFFSET;
             float anchorY = y * Settings.MAP_DST_Y + OFFSET_Y + DungeonMapScreen.offsetY - ZoneShapeMaker.FB_OFFSET;
 
-            Color oldColor = sb.getColor().cpy();
-
-            Color zoneColor = getAdjustedColor().cpy().mul(1f, 1f, 1f, alpha * 0.5f);
-            sb.setColor(zoneColor);
+            Color oldColor = sb.getColor();
+            sb.setColor(getAdjustedColor().cpy().mul(1f, 1f, 1f, alpha * 0.5f));
             sb.draw(shapeRegion, anchorX, anchorY);
-
             sb.setColor(oldColor);
 
             boolean showTooltip = false;

--- a/src/main/java/spireMapOverhaul/abstracts/AbstractZone.java
+++ b/src/main/java/spireMapOverhaul/abstracts/AbstractZone.java
@@ -211,8 +211,15 @@ public abstract class AbstractZone {
             }
             float anchorX = x * SPACING_X + OFFSET_X - ZoneShapeMaker.FB_OFFSET;
             float anchorY = y * Settings.MAP_DST_Y + OFFSET_Y + DungeonMapScreen.offsetY - ZoneShapeMaker.FB_OFFSET;
-            sb.setColor(getAdjustedColor().cpy().mul(1f, 1f, 1f, alpha*0.5f));
+
+            Color oldColor = sb.getColor().cpy();
+
+            Color zoneColor = getAdjustedColor().cpy().mul(1f, 1f, 1f, alpha * 0.5f);
+            sb.setColor(zoneColor);
             sb.draw(shapeRegion, anchorX, anchorY);
+
+            sb.setColor(oldColor);
+
             boolean showTooltip = false;
             for (Hitbox hb : hitboxes) {
                 hb.move(hitboxRelativePositions.get(hb).getKey() + anchorX, hitboxRelativePositions.get(hb).getValue() + anchorY);
@@ -226,13 +233,10 @@ public abstract class AbstractZone {
                 float tooltipWidth = 280.0F * Settings.scale;
                 float lineHeight = 26.0F * Settings.scale;
                 float tooltipHeight = -FontHelper.getSmartHeight(FontHelper.tipBodyFont, tooltipBody, tooltipWidth, lineHeight) -7f * Settings.scale;
-
                 float tooltipY = InputHelper.mY - 65f * Settings.scale;
-
                 if (tooltipY - tooltipHeight < 0) {
                     tooltipY = tooltipHeight;
                 }
-
                 TipHelper.renderGenericTip(InputHelper.mX + 40f * Settings.scale, tooltipY, name, tooltipBody);
             }
         }


### PR DESCRIPTION
Previously, for me at least, a new issue emerged where some biomes would have their transparencies heavily increased. See below, there are three zones: Gremlin Camp, where the zone outline is entirely invisible, Heavenly Clouds, where the zone outline is BARELY visible, and Mana Surge, where it looks fine.

![image](https://github.com/user-attachments/assets/56430890-dacd-45eb-94f8-24aba1bd1e1d)

This change makes it so that all biomes have consistent transparency:

![image](https://github.com/user-attachments/assets/0c5a8c15-5da1-475c-b0fa-1d456430f636)

Again, this was a personal issue and I'm not sure how many others have experienced the same transparency discrepancies, but I hope there's some others out there who are helped by this.