### PR TITLE
Fixed a bug where the zone outlines would disappear between Acts if Minty Spire's minimap was active

### DIFF
--- a/src/main/java/spireMapOverhaul/patches/MintySpireMinimapPatches.java
+++ b/src/main/java/spireMapOverhaul/patches/MintySpireMinimapPatches.java
@@ -1,5 +1,3 @@
-
-
 package spireMapOverhaul.patches;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;

--- a/src/main/java/spireMapOverhaul/patches/MintySpireMinimapPatches.java
+++ b/src/main/java/spireMapOverhaul/patches/MintySpireMinimapPatches.java
@@ -1,0 +1,51 @@
+
+
+package spireMapOverhaul.patches;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import spireMapOverhaul.BetterMapGenerator;
+import spireMapOverhaul.abstracts.AbstractZone;
+
+public class MintySpireMinimapPatches {
+    private static boolean needsReset = false;
+    private static int resetFrameDelay = 0;
+    private static final int FRAME_DELAY = 2;  // Wait a couple frames before resetting
+
+    @SpirePatch(
+            clz = AbstractDungeon.class,
+            method = "dungeonTransitionSetup"
+    )
+    public static class TransitionPatch {
+        @SpirePostfixPatch
+        public static void Postfix() {
+            needsReset = true;
+            resetFrameDelay = FRAME_DELAY;
+        }
+    }
+
+    @SpirePatch(
+            optional = true,
+            cls = "mintySpire.patches.map.MiniMapDisplay",
+            method = "renderMinimap"
+    )
+    public static class MinimapPatch {
+        @SpirePostfixPatch
+        public static void Postfix(SpriteBatch sb, float x, float y, Object camera) {
+            if (needsReset) {
+                if (resetFrameDelay > 0) {
+                    resetFrameDelay--;
+                } else {
+                    for (AbstractZone zone : BetterMapGenerator.getActiveZones(AbstractDungeon.map)) {
+                        if (zone != null) {
+                            zone.shapeRegion = null;
+                        }
+                    }
+                    needsReset = false;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Note that the only quirk I could find with this is that between Acts, if the minimap is active, it takes a short amount of time for the zone outlines to kick in (2 or so frames from the FRAME_DELAY), but that's definitely an improvement from them not rendering at all.