### PR TITLE
Bugfix: Humidity Centurion "Owner" occasionally shielded player instead of attacking like he's supposed to

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/humidity/encounters/monsters/HumidityCenturion.java
+++ b/src/main/java/spireMapOverhaul/zones/humidity/encounters/monsters/HumidityCenturion.java
@@ -92,6 +92,9 @@ public class HumidityCenturion extends Centurion {
                 }
             }
 
+            if (Fields.isSolo.get(this))
+                aliveCount = 1;
+
             if (aliveCount > 1) {
                 this.setMove((byte) 2, Intent.DEFEND);
             } else {


### PR DESCRIPTION
Pull 278 commit fcd8120 removed a large number of patches to vanilla Centurion and replaced them with a dedicated HumidityCenturion monster for the "Owner" vs "Murderer" encounter.  The behavior of HumidityCenturion is meant to be identical to the previously-patched Centurion, including permanent "enrage mode" by setting the aliveCount variable to 1.

When writing HumidityCenturion, I overlooked that the getMove function calculates aliveCount in two different places and forgot to set it in the second situation. This caused "Owner" to occasionally drop out of enrage mode and shield the player instead of attacking "Murderer".