### PR TITLE
Crash fixes

### DIFF
--- a/src/main/java/spireMapOverhaul/zones/humidity/HumidityZone.java
+++ b/src/main/java/spireMapOverhaul/zones/humidity/HumidityZone.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 public class HumidityZone extends AbstractZone implements OnTravelZone, CombatModifyingZone, RenderableZone {
     public static final String ID = "Humidity";
 
-    public static final boolean DEBUG_PLAYER_IS_ALWAYS_IN_ZONE = false;
+    public static final boolean DEBUG_PLAYER_IS_ALWAYS_IN_ZONE = false;  //ALWAYS CHANGE THIS TO FALSE BEFORE SENDING A PULL REQUEST
     public static final String DEBUG_FORCE_EVENT_ID = "";
 
     private final Texture humidibot = TexLoader.getTexture(SpireAnniversary6Mod.makeBackgroundPath("humidity/humidibot.png"));

--- a/src/main/java/spireMapOverhaul/zones/humidity/cards/powerelic/implementation/PowerelicCard.java
+++ b/src/main/java/spireMapOverhaul/zones/humidity/cards/powerelic/implementation/PowerelicCard.java
@@ -16,6 +16,7 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.FontHelper;
 import com.megacrit.cardcrawl.helpers.RelicLibrary;
 import com.megacrit.cardcrawl.localization.CardStrings;
@@ -232,12 +233,7 @@ public class PowerelicCard extends AbstractSMOCard implements OnObtainCard, Cust
             //      note that for those cards, we call loseRelic even if the relic isn't currently activated
             if (!PowerelicAllowlist.isEssentialEquipRelic(capturedRelic)
                     || Wiz.adp().relics.contains(capturedRelic)) {
-                boolean success = Wiz.adp().loseRelic(capturedRelic.relicId);
-                if (!success) {
-                    //if we're here, then loseRelic failed because the relic wasn't in the player relic list
-                    // (inactive) and we need to onUnequip it manually.
-                    capturedRelic.onUnequip();
-                }
+                AbstractDungeon.effectsQueue.add(new RemoveRelicGameEffect(capturedRelic));
             }
             //Also note that if for whatever reason we have a permanent non-Powerelic relic in the player relic bar
             // and the player removes a card with the same relic ID, the above logic will become very confused

--- a/src/main/java/spireMapOverhaul/zones/humidity/cards/powerelic/implementation/RemoveRelicGameEffect.java
+++ b/src/main/java/spireMapOverhaul/zones/humidity/cards/powerelic/implementation/RemoveRelicGameEffect.java
@@ -1,0 +1,37 @@
+package spireMapOverhaul.zones.humidity.cards.powerelic.implementation;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.vfx.AbstractGameEffect;
+import spireMapOverhaul.util.Wiz;
+
+public class RemoveRelicGameEffect extends AbstractGameEffect {
+
+    //Used to remove relics safely (i.e. dodge ConcurrentModificationException) when a PowerelicCard is removed from the master deck.
+
+    AbstractRelic capturedRelic;
+
+    public RemoveRelicGameEffect(AbstractRelic capturedRelic) {
+        super();
+        this.capturedRelic=capturedRelic;
+    }
+
+    @Override
+    public void update() {
+        boolean success = Wiz.adp().loseRelic(capturedRelic.relicId);
+        if (!success) {
+            //if we're here, then loseRelic failed because the relic wasn't in the player relic list
+            // (inactive) and we need to onUnequip it manually.
+            capturedRelic.onUnequip();
+        }
+        this.isDone = true;
+    }
+
+    @Override
+    public void render(SpriteBatch spriteBatch) {
+    }
+
+    @Override
+    public void dispose() {
+    }
+}

--- a/src/main/java/spireMapOverhaul/zones/humidity/powers/BaseballPower.java
+++ b/src/main/java/spireMapOverhaul/zones/humidity/powers/BaseballPower.java
@@ -63,6 +63,7 @@ public class BaseballPower extends AbstractSMOPower {
         @SpirePrefixPatch
         public static void Foo(PowerBuffEffect __instance, @ByRef String[] msg) {
             if(msg[0]==null)return;
+            if(msg[0].isEmpty())return;
             //Don't say "+1 Bottom of the Ninth" when the player plays a Strike.
 
             if (msg[0].charAt(0) == '+' && msg[0].contains(powerStrings.NAME)) {

--- a/src/main/java/spireMapOverhaul/zones/humidity/powers/BaseballPower.java
+++ b/src/main/java/spireMapOverhaul/zones/humidity/powers/BaseballPower.java
@@ -62,6 +62,7 @@ public class BaseballPower extends AbstractSMOPower {
     public static class ReplaceOverheadTextPatch {
         @SpirePrefixPatch
         public static void Foo(PowerBuffEffect __instance, @ByRef String[] msg) {
+            if(msg[0]==null)return;
             //Don't say "+1 Bottom of the Ninth" when the player plays a Strike.
 
             if (msg[0].charAt(0) == '+' && msg[0].contains(powerStrings.NAME)) {

--- a/src/main/java/spireMapOverhaul/zones/humidity/powers/BaseballPower.java
+++ b/src/main/java/spireMapOverhaul/zones/humidity/powers/BaseballPower.java
@@ -64,7 +64,7 @@ public class BaseballPower extends AbstractSMOPower {
         public static void Foo(PowerBuffEffect __instance, @ByRef String[] msg) {
             if(msg[0]==null)return;
             if(msg[0].isEmpty())return;
-            //Don't say "+1 Bottom of the Ninth" when the player plays a Strike.
+            //Don't say "+1 Bottom of the Ninth" when twhe player plays a Strike.
 
             if (msg[0].charAt(0) == '+' && msg[0].contains(powerStrings.NAME)) {
                 //unfortunately we don't have a reference to the original power to get the stack count.


### PR DESCRIPTION
_"game crashed in heavenly clouds when stunning against a single slaver"_
_"Cause:
java.lang.StringIndexOutOfBoundsException: String index out of range: 0
at java.lang.String.charAt(String.java:658)
at spireMapOverhaul.zones.humidity.powers.BaseballPower$ReplaceOverheadTextPatch.Foo(BaseballPower.java:67)"_

Diagnosis: InvisibleFlightTracker's displayed name is "".

Added "if(msg[0]==null)return;" and "if(msg[0].isEmpty())return;" to start of patch.

--

 _"I confirmed by reloading the save that the Feather Duster didn't crash when removing anything else, it was just the one that was 'active'. I also removed the Juzu Bracelet Powerelic through the console, and had **no problems** when doing so, indicating it likely has to do with animation or something?"_

Diagnosis: Relics which remove cards on pickup crash the game if a relic is removed at the same time.

Added RemoveRelicGameEffect and queued it so it does not run concurrently with relic pickup. **Spire Café must also be updated.**
